### PR TITLE
Snapshots configuration

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -932,7 +932,7 @@ func (c *Contracts) DeployContracts(ctx context.Context, account accounts.Accoun
 	q(vu.add("setMinEthSnapshotSize(uint256)", snapshotsFacet))
 	q(vu.add("minEthSnapshotSize()", snapshotsFacet))
 	q(vu.add("setMinMadSnapshotSize(uint256)", snapshotsFacet))
-	q(vu.add("minMadSnapshotSize(uint256)", snapshotsFacet))
+	q(vu.add("minMadSnapshotSize()", snapshotsFacet))
 	q(vu.add("setEpoch(uint256)", snapshotsFacet))
 	q(vu.add("epoch()", snapshotsFacet))
 	q(vu.add("getChainIdFromSnapshot(uint256)", snapshotsFacet))

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -1078,7 +1078,7 @@ func (c *Contracts) DeployContracts(ctx context.Context, account accounts.Accoun
 	logAndEat(logger, err)
 	q(tx)
 
-	tx, err = c.Snapshots.SetMinEthSnapshotSize(txnOpts, big.NewInt(1024))
+	tx, err = c.Snapshots.SetMinMadSnapshotSize(txnOpts, big.NewInt(1024))
 	logAndEat(logger, err)
 	q(tx)
 

--- a/blockchain/monitor/services.go
+++ b/blockchain/monitor/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/MadBase/MadNet/application/deposit"
 	"github.com/MadBase/MadNet/blockchain"
@@ -328,7 +329,7 @@ func (svcs *Services) PersistSnapshot(blockHeader *objs.BlockHeader) error {
 	rawSigGroup := blockHeader.SigGroup
 
 	// Do the mechanics
-	txnOpts, err := svcs.eth.GetTransactionOpts(context.TODO(), svcs.eth.GetDefaultAccount())
+	txnOpts, err := svcs.eth.GetTransactionOpts(context.Background(), svcs.eth.GetDefaultAccount())
 	if err != nil {
 		logger.Errorf("Could not create transaction for snapshot: %v", err)
 		return nil //CAN NOT RETURN ERROR OR SUBSCRIPTION IS LOST!
@@ -340,7 +341,10 @@ func (svcs *Services) PersistSnapshot(blockHeader *objs.BlockHeader) error {
 		return nil //CAN NOT RETURN ERROR OR SUBSCRIPTION IS LOST!
 	}
 
-	rcpt, err := eth.WaitForReceipt(context.TODO(), txn)
+	toCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	rcpt, err := eth.WaitForReceipt(toCtx, txn)
 	if err != nil {
 		logger.Errorf("Failed to retrieve snapshot receipt: %v", err)
 		return nil //CAN NOT RETURN ERROR OR SUBSCRIPTION IS LOST!


### PR DESCRIPTION
## Scope

Fixed deploy time configuration for Snapshots smart contract. Added timeout to snapshot functionality.

## Why

Snapshot intervals were incorrectly configured, still changeable but default values are as expected now. Default: 1024 blocks.

After a certain amount of time waiting for snapshot to succeed we should try again to prevent needless blocking. Timeout: 5 minutes.