### PR TITLE
Set correct UPnP logger

### DIFF
--- a/transport/upnp.go
+++ b/transport/upnp.go
@@ -22,7 +22,7 @@ type UPnPMapper struct {
 
 func NewUPnPMapper(logger *logrus.Logger, port int) (*UPnPMapper, error) {
 	manager := &UPnPMapper{
-		logger: logrus.New(),
+		logger: logger,
 		port:   uint16(port),
 	}
 	return manager, nil


### PR DESCRIPTION
## Scope

The UPnP logger is set to the one passed as argument during initialization. Previously it was using a default logger, ignoring the one passed as argument.