### PR TITLE
minvalue is now max by default

### DIFF
--- a/application/objs/uint256/uint256.go
+++ b/application/objs/uint256/uint256.go
@@ -436,3 +436,9 @@ func Two() *Uint256 {
 	_, _ = u.FromUint64(2)
 	return u
 }
+
+// Max returns the maximum value
+func Max() *Uint256 {
+	const uint64max uint64 = 1<<64 - 1
+	return &Uint256{val: &uint256.Int{uint64max, uint64max, uint64max, uint64max}}
+}

--- a/localrpc/handlers.go
+++ b/localrpc/handlers.go
@@ -235,10 +235,12 @@ func (srpc *Handlers) HandleLocalStateGetValueForOwner(ctx context.Context, req 
 	}
 
 	srpc.logger.Debugf("HandleLocalStateGetValueForOwner: %v", req)
-	minValue := &uint256.Uint256{}
-	err := minValue.UnmarshalString(req.Minvalue)
-	if err != nil {
-		return nil, err
+	minValue := uint256.Max()
+	if req.Minvalue != "" {
+		err := minValue.UnmarshalString(req.Minvalue)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	accountH := req.Account


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2497122

## Scope
`minValue` may now not be passed to `GetValueForOwner` and all UTXOs will be returned