### PR TITLE
Fix tests after last PR

### DIFF
--- a/blockchain/dkg/dkgtasks/place_holder_task.go
+++ b/blockchain/dkg/dkgtasks/place_holder_task.go
@@ -16,7 +16,7 @@ func NewPlaceHolder(state *objects.DkgState) *PlaceHolder {
 	return &PlaceHolder{state: state}
 }
 
-func (ph *PlaceHolder) Initialize(ctx context.Context, logger *logrus.Entry, eth interfaces.Ethereum) error {
+func (ph *PlaceHolder) Initialize(ctx context.Context, logger *logrus.Entry, eth interfaces.Ethereum, state interface{}) error {
 	logger.Infof("ph dowork")
 	return nil
 }

--- a/blockchain/objects/scheduler_test.go
+++ b/blockchain/objects/scheduler_test.go
@@ -257,7 +257,7 @@ func TestMarshal(t *testing.T) {
 type adminTaskMock struct {
 }
 
-func (ph *adminTaskMock) Initialize(ctx context.Context, logger *logrus.Entry, eth interfaces.Ethereum) error {
+func (ph *adminTaskMock) Initialize(ctx context.Context, logger *logrus.Entry, eth interfaces.Ethereum, state interface{}) error {
 	return nil
 }
 func (ph *adminTaskMock) DoWork(ctx context.Context, logger *logrus.Entry, eth interfaces.Ethereum) error {


### PR DESCRIPTION
## Scope

The Task interface's Initialize function takes an additional parameter. This updates mocks to reflect that.

## Why?

Missed it before.
