### PR TITLE
Updated error messages in consensus objects.

### DIFF
--- a/application/objs/tx.go
+++ b/application/objs/tx.go
@@ -32,6 +32,9 @@ type Tx struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // Tx object
 func (b *Tx) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("tx.unmarshalBinary: tx not initialized")
+	}
 	bc, err := tx.Unmarshal(data)
 	if err != nil {
 		return err
@@ -63,6 +66,9 @@ func (b *Tx) MarshalBinary() ([]byte, error) {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *Tx) UnmarshalCapn(bc mdefs.Tx) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("tx.unmarshalCapn: tx not initialized")
+	}
 	if err := tx.Validate(bc); err != nil {
 		return err
 	}

--- a/consensus/objs/bclms.go
+++ b/consensus/objs/bclms.go
@@ -22,6 +22,9 @@ type BClaims struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // BClaims object
 func (b *BClaims) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("BClaims.UnmarshalBinary; bclaims not initialized")
+	}
 	bc, err := bclaims.Unmarshal(data)
 	if err != nil {
 		return err
@@ -33,8 +36,14 @@ func (b *BClaims) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the BClaims object and returns the canonical
 // byte slice
 func (b *BClaims) MarshalBinary() ([]byte, error) {
-	if b == nil || b.ChainID == 0 || b.Height == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("BClaims.MarshalBinary; bclaims not initialized")
+	}
+	if b.ChainID == 0 {
+		return nil, errorz.ErrInvalid{}.New("BClaims.MarshalBinary; chainID is zero")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("BClaims.MarshalBinary; height is zero")
 	}
 	bc, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -46,6 +55,9 @@ func (b *BClaims) MarshalBinary() ([]byte, error) {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *BClaims) UnmarshalCapn(bc mdefs.BClaims) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("BClaims.UnmarshalCapn; bclaims not initialized")
+	}
 	err := bclaims.Validate(bc)
 	if err != nil {
 		return err
@@ -58,10 +70,10 @@ func (b *BClaims) UnmarshalCapn(bc mdefs.BClaims) error {
 	b.StateRoot = bc.StateRoot()
 	b.TxRoot = bc.TxRoot()
 	if b.Height < 1 {
-		return errorz.ErrInvalid{}.New("capn bclaims bad height")
+		return errorz.ErrInvalid{}.New("BClaims.UnmarshalCapn; height is zero")
 	}
 	if b.ChainID < 1 {
-		return errorz.ErrInvalid{}.New("capn bclaims bad cid")
+		return errorz.ErrInvalid{}.New("BClaims.UnmarshalCapn; chainID is zero")
 	}
 	return nil
 }
@@ -69,7 +81,7 @@ func (b *BClaims) UnmarshalCapn(bc mdefs.BClaims) error {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *BClaims) MarshalCapn(seg *capnp.Segment) (mdefs.BClaims, error) {
 	if b == nil {
-		return mdefs.BClaims{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.BClaims{}, errorz.ErrInvalid{}.New("BClaims.MarshalCapn; bclaims not initialized")
 	}
 	var bc mdefs.BClaims
 	if seg == nil {

--- a/consensus/objs/bhIndKey.go
+++ b/consensus/objs/bhIndKey.go
@@ -16,10 +16,10 @@ type BlockHeaderHashIndexKey struct {
 // BlockHeaderHashIndexKey object
 func (b *BlockHeaderHashIndexKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey.UnmarshalBinary; bhhik not initialized")
 	}
 	if len(data) != (constants.HashLen + 2) {
-		return errorz.ErrInvalid{}.New("Invalid BlockHeaderHashIndexKey")
+		return errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	b.BlockHash = utils.CopySlice(data[2:])
@@ -30,13 +30,13 @@ func (b *BlockHeaderHashIndexKey) UnmarshalBinary(data []byte) error {
 // the canonical byte slice
 func (b *BlockHeaderHashIndexKey) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey.MarshalBinary; bhhik not initialized")
 	}
 	if len(b.BlockHash) != constants.HashLen {
-		return nil, errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey: invalid BlockHash")
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey.MarshalBinary: incorrect BlockHash length")
 	}
 	if len(b.Prefix) != 2 {
-		return nil, errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey: invalid Prefix")
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHashIndexKey.MarshalBinary: incorrect Prefix length")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)

--- a/consensus/objs/cbkey.go
+++ b/consensus/objs/cbkey.go
@@ -15,10 +15,10 @@ type BlockHeaderHeightKey struct {
 // BlockHeaderHeightKey object
 func (b *BlockHeaderHeightKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("BlockHeaderHeightKey.UnmarshalBinary; bhhk not initialized")
 	}
 	if len(data) != 6 {
-		return errorz.ErrInvalid{}.New("Invalid data for BlockHeaderHeightKey unmarshalling")
+		return errorz.ErrInvalid{}.New("BlockHeaderHeightKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	nb, err := utils.UnmarshalUint32(data[2:6])
@@ -26,7 +26,7 @@ func (b *BlockHeaderHeightKey) UnmarshalBinary(data []byte) error {
 		return err
 	}
 	if nb == 0 {
-		return errorz.ErrInvalid{}.New("Invalid data for BlockHeaderHeightKey unmarshalling; height == 0")
+		return errorz.ErrInvalid{}.New("BlockHeaderHeightKey.UnmarshalBinary; height is zero")
 	}
 	b.Height = nb
 	return nil
@@ -35,8 +35,14 @@ func (b *BlockHeaderHeightKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the BlockHeaderHeightKey object and returns the canonical
 // byte slice
 func (b *BlockHeaderHeightKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || b.Height == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHeightKey.MarshalBinary; bhhk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHeightKey.MarshalBinary; incorrect Prefix length")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("BlockHeaderHeightKey.MarshalBinary; height is zero")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)

--- a/consensus/objs/estore.go
+++ b/consensus/objs/estore.go
@@ -27,6 +27,9 @@ type EncryptedStore struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // EncryptedStore object
 func (b *EncryptedStore) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("estore.UnmarshalBinary; estore not initialized")
+	}
 	bh, err := estore.Unmarshal(data)
 	if err != nil {
 		return err
@@ -36,6 +39,9 @@ func (b *EncryptedStore) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *EncryptedStore) UnmarshalCapn(bh mdefs.EncryptedStore) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("estore.UnmarshalCapn; estore not initialized")
+	}
 	err := estore.Validate(bh)
 	if err != nil {
 		return err
@@ -50,6 +56,9 @@ func (b *EncryptedStore) UnmarshalCapn(bh mdefs.EncryptedStore) error {
 // MarshalBinary takes the EncryptedStore object and returns the canonical
 // byte slice
 func (b *EncryptedStore) MarshalBinary() ([]byte, error) {
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("estore.MarshalBinary; estore not initialized")
+	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
 		return nil, err
@@ -64,7 +73,7 @@ func (b *EncryptedStore) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *EncryptedStore) MarshalCapn(seg *capnp.Segment) (mdefs.EncryptedStore, error) {
 	if b == nil {
-		return mdefs.EncryptedStore{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.EncryptedStore{}, errorz.ErrInvalid{}.New("estore.MarshalCapn; estore not initialized")
 	}
 	var bh mdefs.EncryptedStore
 	if seg == nil {
@@ -104,9 +113,12 @@ func (b *EncryptedStore) MarshalCapn(seg *capnp.Segment) (mdefs.EncryptedStore, 
 	return bh, nil
 }
 
-// Encrypt encrypts b.ClearText and writes the result to b.cypherText;
-// afterwards, it zeros b.ClearText and sets its pointer to nil
+// Encrypt encrypts estore.ClearText and writes the result to estore.cypherText;
+// afterwards, it zeros estore.ClearText and sets its pointer to nil
 func (b *EncryptedStore) Encrypt(resolver interfaces.KeyResolver) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("estore.Encrypt; estore not initialized")
+	}
 	key, err := resolver.GetKey(b.Kid)
 	if err != nil {
 		return err
@@ -132,8 +144,11 @@ func (b *EncryptedStore) Encrypt(resolver interfaces.KeyResolver) error {
 	return nil
 }
 
-// Decrypt decrypts b.cypherText and saves the result to b.ClearText
+// Decrypt decrypts estore.cypherText and saves the result to estore.ClearText
 func (b *EncryptedStore) Decrypt(resolver interfaces.KeyResolver) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("estore.Decrypt; estore not initialized")
+	}
 	key, err := resolver.GetKey(b.Kid)
 	if err != nil {
 		return err

--- a/consensus/objs/nh.go
+++ b/consensus/objs/nh.go
@@ -26,6 +26,9 @@ type NextHeight struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // NextHeight object
 func (b *NextHeight) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.UnmarshalBinary; nh not initialized")
+	}
 	bh, err := nextheight.Unmarshal(data)
 	if err != nil {
 		return err
@@ -36,6 +39,9 @@ func (b *NextHeight) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *NextHeight) UnmarshalCapn(bh mdefs.NextHeight) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.UnmarshalCapn; nh not initialized")
+	}
 	b.NHClaims = &NHClaims{}
 	err := nextheight.Validate(bh)
 	if err != nil {
@@ -59,7 +65,7 @@ func (b *NextHeight) UnmarshalCapn(bh mdefs.NextHeight) error {
 // byte slice
 func (b *NextHeight) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("NextHeight.MarshalBinary; nh not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -72,7 +78,7 @@ func (b *NextHeight) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *NextHeight) MarshalCapn(seg *capnp.Segment) (mdefs.NextHeight, error) {
 	if b == nil {
-		return mdefs.NextHeight{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.NextHeight{}, errorz.ErrInvalid{}.New("NextHeight.MarshalCapn; nh not initialized")
 	}
 	var bh mdefs.NextHeight
 	if seg == nil {
@@ -109,8 +115,17 @@ func (b *NextHeight) MarshalCapn(seg *capnp.Segment) (mdefs.NextHeight, error) {
 }
 
 func (b *NextHeight) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
-	if b == nil || b.NHClaims == nil || b.NHClaims.Proposal == nil || b.NHClaims.Proposal.PClaims == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.ValidateSignatures; nh not initialized")
+	}
+	if b.NHClaims == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.ValidateSignatures; nhclaims not initialized")
+	}
+	if b.NHClaims.Proposal == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.ValidateSignatures; proposal not initialized")
+	}
+	if b.NHClaims.Proposal.PClaims == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.ValidateSignatures; pclaims not initialized")
 	}
 	err := b.NHClaims.ValidateSignatures(secpVal, bnVal)
 	if err != nil {
@@ -162,8 +177,17 @@ func (b *NextHeight) Plagiarize(secpSigner *crypto.Secp256k1Signer, bnSigner *cr
 }
 
 func (b *NextHeight) Sign(secpSigner *crypto.Secp256k1Signer, bnSigner *crypto.BNGroupSigner) error {
-	if b == nil || b.NHClaims == nil || b.NHClaims.Proposal == nil || b.NHClaims.Proposal.PClaims == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.Sign; nh not initialized")
+	}
+	if b.NHClaims == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.Sign; nhclaims not initialized")
+	}
+	if b.NHClaims.Proposal == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.Sign; proposal not initialized")
+	}
+	if b.NHClaims.Proposal.PClaims == nil {
+		return errorz.ErrInvalid{}.New("NextHeight.Sign; pclaims not initialized")
 	}
 	canonicalEncoding, err := b.NHClaims.Proposal.PClaims.MarshalBinary()
 	if err != nil {

--- a/consensus/objs/nhc.go
+++ b/consensus/objs/nhc.go
@@ -19,6 +19,9 @@ type NHClaims struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // NHClaims object
 func (b *NHClaims) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NHClaims.UnmarshalBinary; nhclaims not initialized")
+	}
 	bh, err := nhclaims.Unmarshal(data)
 	if err != nil {
 		return err
@@ -29,6 +32,9 @@ func (b *NHClaims) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *NHClaims) UnmarshalCapn(bh mdefs.NHClaims) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NHClaims.UnmarshalCapn; nhclaims not initialized")
+	}
 	b.Proposal = &Proposal{}
 	err := nhclaims.Validate(bh)
 	if err != nil {
@@ -46,7 +52,7 @@ func (b *NHClaims) UnmarshalCapn(bh mdefs.NHClaims) error {
 // byte slice
 func (b *NHClaims) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("NHClaims.MarshalBinary; nhclaims not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -59,7 +65,7 @@ func (b *NHClaims) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *NHClaims) MarshalCapn(seg *capnp.Segment) (mdefs.NHClaims, error) {
 	if b == nil {
-		return mdefs.NHClaims{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.NHClaims{}, errorz.ErrInvalid{}.New("NHClaims.MarshalCapn; nhclaims not initialized")
 	}
 	var bh mdefs.NHClaims
 	if seg == nil {
@@ -95,8 +101,11 @@ func (b *NHClaims) MarshalCapn(seg *capnp.Segment) (mdefs.NHClaims, error) {
 }
 
 func (b *NHClaims) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
-	if b == nil || b.Proposal == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NHClaims.ValidateSignatures; nhclaims not initialized")
+	}
+	if b.Proposal == nil {
+		return errorz.ErrInvalid{}.New("NHClaims.ValidateSignatures; proposal not initialized")
 	}
 	err := b.Proposal.ValidateSignatures(secpVal, bnVal)
 	if err != nil {

--- a/consensus/objs/nr.go
+++ b/consensus/objs/nr.go
@@ -21,6 +21,9 @@ type NextRound struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // NextRound object
 func (b *NextRound) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextRound.UnmarshalBinary; nr not initialized")
+	}
 	bh, err := nextround.Unmarshal(data)
 	if err != nil {
 		return err
@@ -31,6 +34,9 @@ func (b *NextRound) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *NextRound) UnmarshalCapn(bh mdefs.NextRound) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NextRound.UnmarshalCapn; nr not initialized")
+	}
 	b.NRClaims = &NRClaims{}
 	err := nextround.Validate(bh)
 	if err != nil {
@@ -48,7 +54,7 @@ func (b *NextRound) UnmarshalCapn(bh mdefs.NextRound) error {
 // byte slice
 func (b *NextRound) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("NextRound.MarshalBinary; nr not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -61,7 +67,7 @@ func (b *NextRound) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *NextRound) MarshalCapn(seg *capnp.Segment) (mdefs.NextRound, error) {
 	if b == nil {
-		return mdefs.NextRound{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.NextRound{}, errorz.ErrInvalid{}.New("NextRound.MarshalCapn; nr not initialized")
 	}
 	var bh mdefs.NextRound
 	if seg == nil {
@@ -98,7 +104,7 @@ func (b *NextRound) MarshalCapn(seg *capnp.Segment) (mdefs.NextRound, error) {
 
 func (b *NextRound) Sign(secpSigner *crypto.Secp256k1Signer, bnSigner *crypto.BNGroupSigner) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("NextRound.Sign; nr not initialized")
 	}
 	err := b.NRClaims.Sign(bnSigner)
 	if err != nil {
@@ -121,7 +127,7 @@ func (b *NextRound) Sign(secpSigner *crypto.Secp256k1Signer, bnSigner *crypto.BN
 
 func (b *NextRound) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("NextRound.ValidateSignatures; nr not initialized")
 	}
 	err := b.NRClaims.ValidateSignatures(bnVal)
 	if err != nil {

--- a/consensus/objs/nrc.go
+++ b/consensus/objs/nrc.go
@@ -22,6 +22,9 @@ type NRClaims struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // NRClaims object
 func (b *NRClaims) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalBinary; nrclaims not initialized")
+	}
 	bh, err := nrclaims.Unmarshal(data)
 	if err != nil {
 		return err
@@ -32,6 +35,9 @@ func (b *NRClaims) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *NRClaims) UnmarshalCapn(bh mdefs.NRClaims) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalCapn; nrclaims not initialized")
+	}
 	b.RCert = &RCert{}
 	b.RClaims = &RClaims{}
 	err := nrclaims.Validate(bh)
@@ -48,16 +54,16 @@ func (b *NRClaims) UnmarshalCapn(bh mdefs.NRClaims) error {
 	}
 	b.SigShare = bh.SigShare()
 	if b.RCert.RClaims.Height != b.RClaims.Height {
-		return errorz.ErrInvalid{}.New("nrc height mismatch")
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalCapn; nrclaims height mismatch")
 	}
 	if b.RCert.RClaims.Round+1 != b.RClaims.Round {
-		return errorz.ErrInvalid{}.New("nrc round not plus 1")
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalCapn; nrclaims round not plus 1")
 	}
 	if b.RCert.RClaims.ChainID != b.RClaims.ChainID {
-		return errorz.ErrInvalid{}.New("nrc cid != cid")
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalCapn; nrclaims chainID != chainID")
 	}
 	if !bytes.Equal(b.RCert.RClaims.PrevBlock, b.RClaims.PrevBlock) {
-		return errorz.ErrInvalid{}.New("nrc prevb != prevb")
+		return errorz.ErrInvalid{}.New("NRClaims.UnmarshalCapn; nrclaims prevBlock != prevBlock")
 	}
 	return nil
 }
@@ -66,7 +72,7 @@ func (b *NRClaims) UnmarshalCapn(bh mdefs.NRClaims) error {
 // byte slice
 func (b *NRClaims) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("NRClaims.MarshalBinary; nrclaims not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -79,7 +85,7 @@ func (b *NRClaims) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *NRClaims) MarshalCapn(seg *capnp.Segment) (mdefs.NRClaims, error) {
 	if b == nil {
-		return mdefs.NRClaims{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.NRClaims{}, errorz.ErrInvalid{}.New("NRClaims.MarshalCapn; nrclaims not initialized")
 	}
 	var bh mdefs.NRClaims
 	if seg == nil {
@@ -124,7 +130,7 @@ func (b *NRClaims) MarshalCapn(seg *capnp.Segment) (mdefs.NRClaims, error) {
 
 func (b *NRClaims) ValidateSignatures(bnVal *crypto.BNGroupValidator) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("NRClaims.ValidateSignatures; nrclaims not initialized")
 	}
 	err := b.RCert.ValidateSignature(bnVal)
 	if err != nil {
@@ -144,7 +150,7 @@ func (b *NRClaims) ValidateSignatures(bnVal *crypto.BNGroupValidator) error {
 
 func (b *NRClaims) Sign(bnSigner *crypto.BNGroupSigner) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("NRClaims.Sign; nrclaims not initialized")
 	}
 	canonicalEncoding, err := b.RClaims.MarshalBinary()
 	if err != nil {

--- a/consensus/objs/os.go
+++ b/consensus/objs/os.go
@@ -20,6 +20,9 @@ type OwnState struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // OwnState object
 func (b *OwnState) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("OwnState.UnmarshalBinary; os not initialized")
+	}
 	bh, err := ostate.Unmarshal(data)
 	if err != nil {
 		return err
@@ -30,6 +33,9 @@ func (b *OwnState) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *OwnState) UnmarshalCapn(bh mdefs.OwnState) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("OwnState.UnmarshalCapn; os not initialized")
+	}
 	b.SyncToBH = &BlockHeader{}
 	b.MaxBHSeen = &BlockHeader{}
 	b.PendingSnapShot = &BlockHeader{}
@@ -63,7 +69,7 @@ func (b *OwnState) UnmarshalCapn(bh mdefs.OwnState) error {
 // byte slice
 func (b *OwnState) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("OwnState.MarshalBinary; os not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -76,7 +82,7 @@ func (b *OwnState) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *OwnState) MarshalCapn(seg *capnp.Segment) (mdefs.OwnState, error) {
 	if b == nil {
-		return mdefs.OwnState{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.OwnState{}, errorz.ErrInvalid{}.New("OwnState.MarshalCapn; os not initialized")
 	}
 	var bh mdefs.OwnState
 	if seg == nil {

--- a/consensus/objs/ovs.go
+++ b/consensus/objs/ovs.go
@@ -23,6 +23,9 @@ type OwnValidatingState struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // OwnValidatingState object
 func (b *OwnValidatingState) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("OwnValidatingState.UnmarshalBinary; ovs not initialized")
+	}
 	bh, err := ovstate.Unmarshal(data)
 	if err != nil {
 		return err
@@ -33,6 +36,9 @@ func (b *OwnValidatingState) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *OwnValidatingState) UnmarshalCapn(bh mdefs.OwnValidatingState) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("OwnValidatingState.UnmarshalCapn; ovs not initialized")
+	}
 	err := ovstate.Validate(bh)
 	if err != nil {
 		return err
@@ -63,7 +69,7 @@ func (b *OwnValidatingState) UnmarshalCapn(bh mdefs.OwnValidatingState) error {
 // byte slice
 func (b *OwnValidatingState) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("OwnValidatingState.MarshalBinary; ovs not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -76,7 +82,7 @@ func (b *OwnValidatingState) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *OwnValidatingState) MarshalCapn(seg *capnp.Segment) (mdefs.OwnValidatingState, error) {
 	if b == nil {
-		return mdefs.OwnValidatingState{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.OwnValidatingState{}, errorz.ErrInvalid{}.New("OwnValidatingState.MarshalCapn; ovs not initialized")
 	}
 	var bh mdefs.OwnValidatingState
 	if seg == nil {

--- a/consensus/objs/pc.go
+++ b/consensus/objs/pc.go
@@ -26,6 +26,9 @@ type PreCommit struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // PreCommit object
 func (b *PreCommit) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.UnmarshalBinary; pc not initialized")
+	}
 	bh, err := precommit.Unmarshal(data)
 	if err != nil {
 		return err
@@ -36,6 +39,9 @@ func (b *PreCommit) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *PreCommit) UnmarshalCapn(bh mdefs.PreCommit) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.UnmarshalCapn; pc not initialized")
+	}
 	b.Proposal = &Proposal{}
 	err := precommit.Validate(bh)
 	if err != nil {
@@ -59,7 +65,7 @@ func (b *PreCommit) UnmarshalCapn(bh mdefs.PreCommit) error {
 // byte slice
 func (b *PreCommit) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("PreCommit.MarshalBinary; pc not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -72,7 +78,7 @@ func (b *PreCommit) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *PreCommit) MarshalCapn(seg *capnp.Segment) (mdefs.PreCommit, error) {
 	if b == nil {
-		return mdefs.PreCommit{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.PreCommit{}, errorz.ErrInvalid{}.New("PreCommit.MarshalCapn; pc not initialized")
 	}
 	var bh mdefs.PreCommit
 	if seg == nil {
@@ -112,8 +118,17 @@ func (b *PreCommit) MarshalCapn(seg *capnp.Segment) (mdefs.PreCommit, error) {
 }
 
 func (b *PreCommit) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
-	if b == nil || b.Proposal == nil || b.Proposal.PClaims == nil || b.Proposal.PClaims.RCert == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.ValidateSignatures; pc not initialized")
+	}
+	if b.Proposal == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.ValidateSignatures; proposal not initialized")
+	}
+	if b.Proposal.PClaims == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.ValidateSignatures; pclaims not initialized")
+	}
+	if b.Proposal.PClaims.RCert == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.ValidateSignatures; rcert not initialized")
 	}
 	err := b.Proposal.ValidateSignatures(secpVal, bnVal)
 	if err != nil {
@@ -181,8 +196,11 @@ func (b *PreCommit) MakeImplPreVotes() (PreVoteList, error) {
 }
 
 func (b *PreCommit) Sign(secpSigner *crypto.Secp256k1Signer) error {
-	if b == nil || b.Proposal == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.Sign; pc not initialized")
+	}
+	if b.Proposal == nil {
+		return errorz.ErrInvalid{}.New("PreCommit.Sign; proposal not initialized")
 	}
 	canonicalEncoding, err := b.Proposal.PClaims.MarshalBinary()
 	if err != nil {

--- a/consensus/objs/pclms.go
+++ b/consensus/objs/pclms.go
@@ -18,6 +18,9 @@ type PClaims struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // PClaims object
 func (b *PClaims) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PClaims.UnmarshalBinary; pclaims not initialized")
+	}
 	bh, err := pclaims.Unmarshal(data)
 	if err != nil {
 		return err
@@ -28,6 +31,9 @@ func (b *PClaims) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *PClaims) UnmarshalCapn(bh mdefs.PClaims) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PClaims.UnmarshalCapn; pclaims not initialized")
+	}
 	b.RCert = &RCert{}
 	b.BClaims = &BClaims{}
 	err := pclaims.Validate(bh)
@@ -43,13 +49,13 @@ func (b *PClaims) UnmarshalCapn(bh mdefs.PClaims) error {
 		return err
 	}
 	if b.RCert.RClaims.ChainID != b.BClaims.ChainID {
-		return errorz.ErrInvalid{}.New("pclaims cid != cid")
+		return errorz.ErrInvalid{}.New("PClaims.UnmarshalCapn; pclaims chainID != chainID")
 	}
 	if b.RCert.RClaims.Height != b.BClaims.Height {
-		return errorz.ErrInvalid{}.New("pclaims h != h")
+		return errorz.ErrInvalid{}.New("PClaims.UnmarshalCapn; pclaims height != height")
 	}
 	if !bytes.Equal(b.RCert.RClaims.PrevBlock[:], b.BClaims.PrevBlock[:]) {
-		return errorz.ErrInvalid{}.New("pclaims prevb != prevb")
+		return errorz.ErrInvalid{}.New("PClaims.UnmarshalCapn; pclaims prevBlock != prevBlock")
 	}
 	return nil
 }
@@ -58,7 +64,7 @@ func (b *PClaims) UnmarshalCapn(bh mdefs.PClaims) error {
 // byte slice
 func (b *PClaims) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("PClaims.MarshalBinary; pclaims not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -71,7 +77,7 @@ func (b *PClaims) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *PClaims) MarshalCapn(seg *capnp.Segment) (mdefs.PClaims, error) {
 	if b == nil {
-		return mdefs.PClaims{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.PClaims{}, errorz.ErrInvalid{}.New("PClaims.MarshalCapn; pclaims not initialized")
 	}
 	var bh mdefs.PClaims
 	if seg == nil {

--- a/consensus/objs/pcn.go
+++ b/consensus/objs/pcn.go
@@ -21,6 +21,9 @@ type PreCommitNil struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // PreCommitNil object
 func (b *PreCommitNil) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommitNil.UnmarshalBinary; pcn not initialized")
+	}
 	bh, err := precommitnil.Unmarshal(data)
 	if err != nil {
 		return err
@@ -31,6 +34,9 @@ func (b *PreCommitNil) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *PreCommitNil) UnmarshalCapn(bh mdefs.PreCommitNil) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreCommitNil.UnmarshalCapn; pcn not initialized")
+	}
 	b.RCert = &RCert{}
 	err := precommitnil.Validate(bh)
 	if err != nil {
@@ -48,7 +54,7 @@ func (b *PreCommitNil) UnmarshalCapn(bh mdefs.PreCommitNil) error {
 // byte slice
 func (b *PreCommitNil) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("PreCommitNil.MarshalBinary; pcn not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -61,7 +67,7 @@ func (b *PreCommitNil) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *PreCommitNil) MarshalCapn(seg *capnp.Segment) (mdefs.PreCommitNil, error) {
 	if b == nil {
-		return mdefs.PreCommitNil{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.PreCommitNil{}, errorz.ErrInvalid{}.New("PreCommitNil.MarshalCapn; pcn not initialized")
 	}
 	var bh mdefs.PreCommitNil
 	if seg == nil {
@@ -98,7 +104,7 @@ func (b *PreCommitNil) MarshalCapn(seg *capnp.Segment) (mdefs.PreCommitNil, erro
 
 func (b *PreCommitNil) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PreCommitNil.ValidateSignatures; pcn not initialized")
 	}
 	err := b.RCert.ValidateSignature(bnVal)
 	if err != nil {

--- a/consensus/objs/phlkey.go
+++ b/consensus/objs/phlkey.go
@@ -16,10 +16,10 @@ type PendingHdrLeafKey struct {
 // PendingHdrLeafKey object
 func (b *PendingHdrLeafKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PendingHdrLeafKey.UnmarshalBinary; phlk not initialized")
 	}
 	if len(data) != constants.HashLen+2 {
-		return errorz.ErrInvalid{}.New("Invalid data for PendingHdrLeafKey unmarshalling")
+		return errorz.ErrInvalid{}.New("PendingHdrLeafKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	b.Key = utils.CopySlice(data[2:])
@@ -29,8 +29,14 @@ func (b *PendingHdrLeafKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the PendingHdrLeafKey object and returns the canonical
 // byte slice
 func (b *PendingHdrLeafKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || len(b.Key) != constants.HashLen {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("PendingHdrLeafKey.MarshalBinary; phlk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("PendingHdrLeafKey.MarshalBinary; incorrect Prefix length")
+	}
+	if len(b.Key) != constants.HashLen {
+		return nil, errorz.ErrInvalid{}.New("PendingHdrLeafKey.MarshalBinary; incorrect key length")
 	}
 	key := []byte{}
 	key = append(key, utils.CopySlice(b.Prefix)...)

--- a/consensus/objs/plkey.go
+++ b/consensus/objs/plkey.go
@@ -16,10 +16,10 @@ type PendingLeafKey struct {
 // PendingLeafKey object
 func (b *PendingLeafKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PendingLeafKey.UnmarshalBinary; plk not initialized")
 	}
 	if len(data) != constants.HashLen+2 {
-		return errorz.ErrInvalid{}.New("Invalid data for BlockHeaderHeightKey unmarshalling")
+		return errorz.ErrInvalid{}.New("PendingLeafKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	b.Key = utils.CopySlice(data[2:])
@@ -29,8 +29,14 @@ func (b *PendingLeafKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the PendingLeafKey object and returns the canonical
 // byte slice
 func (b *PendingLeafKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || len(b.Key) != constants.HashLen {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("PendingLeafKey.MarshalBinary; plk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("PendingLeafKey.MarshalBinary; incorrect Prefix length")
+	}
+	if len(b.Key) != constants.HashLen {
+		return nil, errorz.ErrInvalid{}.New("PendingLeafKey.MarshalBinary; incorrect key length")
 	}
 	key := []byte{}
 	key = append(key, utils.CopySlice(b.Prefix)...)

--- a/consensus/objs/pnkey.go
+++ b/consensus/objs/pnkey.go
@@ -16,10 +16,10 @@ type PendingNodeKey struct {
 // PendingNodeKey object
 func (b *PendingNodeKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PendingNodeKey.UnmarshalBinary; pnk not initialized")
 	}
 	if len(data) != constants.HashLen+2 {
-		return errorz.ErrInvalid{}.New("Invalid data for PendingNodeKey unmarshalling")
+		return errorz.ErrInvalid{}.New("PendingNodeKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	b.Key = utils.CopySlice(data[2:])
@@ -29,8 +29,14 @@ func (b *PendingNodeKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the PendingNodeKey object and returns the canonical
 // byte slice
 func (b *PendingNodeKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || len(b.Key) != constants.HashLen {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("PendingNodeKey.MarshalBinary; pnk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("PendingNodeKey.MarshalBinary; incorrect Prefix length")
+	}
+	if len(b.Key) != constants.HashLen {
+		return nil, errorz.ErrInvalid{}.New("PendingNodeKey.MarshalBinary; incorrect key length")
 	}
 	key := []byte{}
 	key = append(key, utils.CopySlice(b.Prefix)...)

--- a/consensus/objs/prop.go
+++ b/consensus/objs/prop.go
@@ -25,6 +25,9 @@ type Proposal struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // Proposal object
 func (b *Proposal) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Proposal.UnmarshalBinary; prop not initialized")
+	}
 	bh, err := proposal.Unmarshal(data)
 	if err != nil {
 		return err
@@ -35,6 +38,9 @@ func (b *Proposal) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *Proposal) UnmarshalCapn(bh mdefs.Proposal) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Proposal.UnmarshalCapn; prop not initialized")
+	}
 	b.PClaims = &PClaims{}
 	err := proposal.Validate(bh)
 	if err != nil {
@@ -53,7 +59,7 @@ func (b *Proposal) UnmarshalCapn(bh mdefs.Proposal) error {
 	b.Signature = utils.CopySlice(bh.Signature())
 	if b.PClaims.RCert.RClaims.Round == constants.DEADBLOCKROUND {
 		if len(b.TxHshLst) != 0 {
-			return errorz.ErrInvalid{}.New("non empty tx hash lst in deadblockround")
+			return errorz.ErrInvalid{}.New("Proposal.UnmarshalCapn; nonempty TxHshLst in DeadBlockRound")
 		}
 	}
 	return nil
@@ -63,7 +69,7 @@ func (b *Proposal) UnmarshalCapn(bh mdefs.Proposal) error {
 // byte slice
 func (b *Proposal) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("Proposal.MarshalBinary; prop not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -76,7 +82,7 @@ func (b *Proposal) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *Proposal) MarshalCapn(seg *capnp.Segment) (mdefs.Proposal, error) {
 	if b == nil {
-		return mdefs.Proposal{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.Proposal{}, errorz.ErrInvalid{}.New("Proposal.MarshalCapn; prop not initialized")
 	}
 	var bh mdefs.Proposal
 	if seg == nil {
@@ -141,11 +147,20 @@ func (b *Proposal) RePropose(secpSigner *crypto.Secp256k1Signer, rc *RCert) (*Pr
 }
 
 func (b *Proposal) Sign(secpSigner *crypto.Secp256k1Signer) error {
-	if b == nil || b.PClaims == nil || b.PClaims.RCert == nil || b.PClaims.RCert.RClaims == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Proposal.Sign; prop not initialized")
+	}
+	if b.PClaims == nil {
+		return errorz.ErrInvalid{}.New("Proposal.Sign; pclaims not initialized")
+	}
+	if b.PClaims.RCert == nil {
+		return errorz.ErrInvalid{}.New("Proposal.Sign; rcert not initialized")
+	}
+	if b.PClaims.RCert.RClaims == nil {
+		return errorz.ErrInvalid{}.New("Proposal.Sign; rclaims not initialized")
 	}
 	if b.PClaims.RCert.RClaims.Round > constants.DEADBLOCKROUND {
-		return errorz.ErrInvalid{}.New("proposal round > DBR")
+		return errorz.ErrInvalid{}.New("Proposal.Sign; Proposal.Round > DBR")
 	}
 	canonicalEncoding, err := b.PClaims.MarshalBinary()
 	if err != nil {
@@ -163,22 +178,31 @@ func (b *Proposal) Sign(secpSigner *crypto.Secp256k1Signer) error {
 }
 
 func (b *Proposal) ValidateSignatures(val *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
-	if b == nil || b.PClaims == nil || b.PClaims.BClaims == nil || b.PClaims.RCert == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; prop not initialized")
+	}
+	if b.PClaims == nil {
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; pclaims not initialized")
+	}
+	if b.PClaims.BClaims == nil {
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; bclaims not initialized")
+	}
+	if b.PClaims.RCert == nil {
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; rcert not initialized")
 	}
 	txRoot, err := MakeTxRoot(b.TxHshLst)
 	if err != nil {
 		return err
 	}
 	if !bytes.Equal(txRoot, b.PClaims.BClaims.TxRoot) {
-		return errorz.ErrInvalid{}.New("proposal txroot mismatch")
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; Proposal TxRoot mismatch")
 	}
 	err = b.PClaims.RCert.ValidateSignature(bnVal)
 	if err != nil {
 		return err
 	}
 	if b.PClaims.RCert.RClaims.Round > constants.DEADBLOCKROUND {
-		return errorz.ErrInvalid{}.New("proposal rcert round > DBR")
+		return errorz.ErrInvalid{}.New("Proposal.ValidateSignatures; Proposal.RCert.Round > DBR")
 	}
 	canonicalEncoding, err := b.PClaims.MarshalBinary()
 	if err != nil {

--- a/consensus/objs/pv.go
+++ b/consensus/objs/pv.go
@@ -21,6 +21,9 @@ type PreVote struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // PreVote object
 func (b *PreVote) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreVote.UnmarshalBinary; pv not initialized")
+	}
 	bh, err := prevote.Unmarshal(data)
 	if err != nil {
 		return err
@@ -31,6 +34,9 @@ func (b *PreVote) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *PreVote) UnmarshalCapn(bh mdefs.PreVote) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreVote.UnmarshalCapn; pv not initialized")
+	}
 	b.Proposal = &Proposal{}
 	err := prevote.Validate(bh)
 	if err != nil {
@@ -48,7 +54,7 @@ func (b *PreVote) UnmarshalCapn(bh mdefs.PreVote) error {
 // byte slice
 func (b *PreVote) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("PreVote.MarshalBinary; pv not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -61,7 +67,7 @@ func (b *PreVote) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *PreVote) MarshalCapn(seg *capnp.Segment) (mdefs.PreVote, error) {
 	if b == nil {
-		return mdefs.PreVote{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.PreVote{}, errorz.ErrInvalid{}.New("PreVote.MarshalCapn; pv not initialized")
 	}
 	var bh mdefs.PreVote
 	if seg == nil {
@@ -98,7 +104,7 @@ func (b *PreVote) MarshalCapn(seg *capnp.Segment) (mdefs.PreVote, error) {
 
 func (b *PreVote) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PreVote.ValidateSignatures; pv not initialized")
 	}
 	err := b.Proposal.ValidateSignatures(secpVal, bnVal)
 	if err != nil {
@@ -122,7 +128,10 @@ func (b *PreVote) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *
 
 func (b *PreVote) Sign(secpSigner *crypto.Secp256k1Signer) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PreVote.Sign; pv not initialized")
+	}
+	if b.Proposal == nil {
+		return errorz.ErrInvalid{}.New("PreVote.Sign; proposal not initialized")
 	}
 	canonicalEncoding, err := b.Proposal.PClaims.MarshalBinary()
 	if err != nil {

--- a/consensus/objs/pvn.go
+++ b/consensus/objs/pvn.go
@@ -21,6 +21,9 @@ type PreVoteNil struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // PreVoteNil object
 func (b *PreVoteNil) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreVoteNil.UnmarshalBinary; pvn not initialized")
+	}
 	bh, err := prevotenil.Unmarshal(data)
 	if err != nil {
 		return err
@@ -31,6 +34,9 @@ func (b *PreVoteNil) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *PreVoteNil) UnmarshalCapn(bh mdefs.PreVoteNil) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("PreVoteNil.UnmarshalCapn; pvn not initialized")
+	}
 	b.RCert = &RCert{}
 	err := prevotenil.Validate(bh)
 	if err != nil {
@@ -48,7 +54,7 @@ func (b *PreVoteNil) UnmarshalCapn(bh mdefs.PreVoteNil) error {
 // byte slice
 func (b *PreVoteNil) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("PreVoteNil.MarshalBinary; pvn not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -61,7 +67,7 @@ func (b *PreVoteNil) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *PreVoteNil) MarshalCapn(seg *capnp.Segment) (mdefs.PreVoteNil, error) {
 	if b == nil {
-		return mdefs.PreVoteNil{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.PreVoteNil{}, errorz.ErrInvalid{}.New("PreVoteNil.MarshalCapn; pvn not initialized")
 	}
 	var bh mdefs.PreVoteNil
 	if seg == nil {
@@ -98,7 +104,7 @@ func (b *PreVoteNil) MarshalCapn(seg *capnp.Segment) (mdefs.PreVoteNil, error) {
 
 func (b *PreVoteNil) ValidateSignatures(secpVal *crypto.Secp256k1Validator, bnVal *crypto.BNGroupValidator) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("PreVoteNil.ValidateSignatures; pvn not initialized")
 	}
 	err := b.RCert.ValidateSignature(bnVal)
 	if err != nil {

--- a/consensus/objs/rclms.go
+++ b/consensus/objs/rclms.go
@@ -20,6 +20,9 @@ type RClaims struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // RClaims object
 func (b *RClaims) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalBinary; rclaims not initialized")
+	}
 	bh, err := rclaims.Unmarshal(data)
 	if err != nil {
 		return err
@@ -30,6 +33,9 @@ func (b *RClaims) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *RClaims) UnmarshalCapn(bh mdefs.RClaims) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalCapn; rclaims not initialized")
+	}
 	err := rclaims.Validate(bh)
 	if err != nil {
 		return err
@@ -39,16 +45,16 @@ func (b *RClaims) UnmarshalCapn(bh mdefs.RClaims) error {
 	b.Round = bh.Round()
 	b.PrevBlock = utils.CopySlice(bh.PrevBlock())
 	if b.Height < 1 {
-		return errorz.ErrInvalid{}.New("rclaims bad height")
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalCapn; height is zero")
 	}
 	if b.Round < 1 {
-		return errorz.ErrInvalid{}.New("rclaims bad round")
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalCapn; round is zero")
 	}
 	if b.ChainID < 1 {
-		return errorz.ErrInvalid{}.New("rclaims bad cid")
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalCapn; chainID is zero")
 	}
 	if b.Round > constants.DEADBLOCKROUND {
-		return errorz.ErrInvalid{}.New("rclaims round too big")
+		return errorz.ErrInvalid{}.New("RClaims.UnmarshalCapn; round > DBR")
 	}
 	return nil
 }
@@ -56,8 +62,20 @@ func (b *RClaims) UnmarshalCapn(bh mdefs.RClaims) error {
 // MarshalBinary takes the RClaims object and returns the canonical
 // byte slice
 func (b *RClaims) MarshalBinary() ([]byte, error) {
-	if b == nil || b.ChainID == 0 || b.Round == 0 || b.Height == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("RClaims.MarshalBinary; rclaims not initialized")
+	}
+	if b.ChainID == 0 {
+		return nil, errorz.ErrInvalid{}.New("RClaims.MarshalBinary; chainID is zero")
+	}
+	if b.Round == 0 {
+		return nil, errorz.ErrInvalid{}.New("RClaims.MarshalBinary; round is zero")
+	}
+	if b.Round > constants.DEADBLOCKROUND {
+		return nil, errorz.ErrInvalid{}.New("RClaims.MarshalBinary; round > DBR")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("RClaims.MarshalBinary; height is zero")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -70,7 +88,7 @@ func (b *RClaims) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *RClaims) MarshalCapn(seg *capnp.Segment) (mdefs.RClaims, error) {
 	if b == nil {
-		return mdefs.RClaims{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.RClaims{}, errorz.ErrInvalid{}.New("RClaims.MarshalCapn; rclaims not initialized")
 	}
 	var bh mdefs.RClaims
 	if seg == nil {

--- a/consensus/objs/rclms_test.go
+++ b/consensus/objs/rclms_test.go
@@ -86,21 +86,6 @@ func TestRClaimsBad(t *testing.T) {
 		t.Fatal("Should have raised error (3)")
 	}
 
-	rcl = &RClaims{
-		ChainID:   cid,
-		Height:    height,
-		Round:     constants.DEADBLOCKROUND + 1,
-		PrevBlock: prevHash,
-	}
-	dataBad, err := rcl.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = rcl2.UnmarshalBinary(dataBad)
-	if err == nil {
-		t.Fatal("Should have raised error (4)")
-	}
-
 	prevHashBad := make([]byte, constants.HashLen+1)
 	rcl = &RClaims{
 		ChainID:   cid,
@@ -114,14 +99,14 @@ func TestRClaimsBad(t *testing.T) {
 	}
 	err = rcl2.UnmarshalBinary(dataBad2)
 	if err == nil {
-		t.Fatal("Should have raised error (5)")
+		t.Fatal("Should have raised error (4)")
 	}
 }
 
 func TestRClaimsBad2(t *testing.T) {
 	cid := uint32(66)
 	height := uint32(113)
-	round := uint32(175)
+	round := uint32(1)
 	prevHash := make([]byte, constants.HashLen)
 
 	rcl := &RClaims{

--- a/consensus/objs/rs.go
+++ b/consensus/objs/rs.go
@@ -39,6 +39,9 @@ type RoundState struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // RoundState object
 func (b *RoundState) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("RoundState.UnmarshalBinary; rs not initialized")
+	}
 	bh, err := rstate.Unmarshal(data)
 	if err != nil {
 		return err
@@ -49,6 +52,9 @@ func (b *RoundState) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *RoundState) UnmarshalCapn(bh mdefs.RoundState) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("RoundState.UnmarshalCapn; rs not initialized")
+	}
 	err := rstate.Validate(bh)
 	if err != nil {
 		return err
@@ -155,7 +161,7 @@ func (b *RoundState) UnmarshalCapn(bh mdefs.RoundState) error {
 // byte slice
 func (b *RoundState) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("RoundState.MarshalBinary; rs not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -168,7 +174,7 @@ func (b *RoundState) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *RoundState) MarshalCapn(seg *capnp.Segment) (mdefs.RoundState, error) {
 	if b == nil {
-		return mdefs.RoundState{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.RoundState{}, errorz.ErrInvalid{}.New("RoundState.MarshalCapn; rs not initialized")
 	}
 	var bh mdefs.RoundState
 	if seg == nil {
@@ -469,7 +475,7 @@ func (b *RoundState) SetRCert(rc *RCert) error {
 func (b *RoundState) SetProposal(v *Proposal) (bool, error) {
 	if IsDeadBlockRound(v) {
 		if len(v.TxHshLst) != 0 {
-			return false, errorz.ErrInvalid{}.New("tx hash in DBR set proposal")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetProposal; tx hash in DBR set proposal")
 		}
 	}
 	ok, err := b.genericSet(v)
@@ -478,7 +484,7 @@ func (b *RoundState) SetProposal(v *Proposal) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt p in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetProposal; corrupt p in dbr")
 		}
 	}
 	return ok, nil
@@ -487,7 +493,7 @@ func (b *RoundState) SetProposal(v *Proposal) (bool, error) {
 func (b *RoundState) SetPreVote(v *PreVote) (bool, error) {
 	if IsDeadBlockRound(v) {
 		if len(v.Proposal.TxHshLst) != 0 {
-			return false, errorz.ErrInvalid{}.New("tx hash in dbr set pv")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreVote; tx hash in dbr set pv")
 		}
 	}
 	ok, err := b.genericSet(v)
@@ -496,7 +502,7 @@ func (b *RoundState) SetPreVote(v *PreVote) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt pv in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreVote; corrupt pv in dbr")
 		}
 	}
 	return ok, nil
@@ -504,7 +510,7 @@ func (b *RoundState) SetPreVote(v *PreVote) (bool, error) {
 
 func (b *RoundState) SetPreVoteNil(v *PreVoteNil) (bool, error) {
 	if IsDeadBlockRound(v) {
-		return false, errorz.ErrInvalid{}.New("dbr tx hash in set pvn")
+		return false, errorz.ErrInvalid{}.New("RoundState.SetPreVoteNil; dbr tx hash in set pvn")
 	}
 	ok, err := b.genericSet(v)
 	if err != nil {
@@ -512,7 +518,7 @@ func (b *RoundState) SetPreVoteNil(v *PreVoteNil) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt pvn in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreVoteNil; corrupt pvn in dbr")
 		}
 	}
 	return ok, nil
@@ -521,7 +527,7 @@ func (b *RoundState) SetPreVoteNil(v *PreVoteNil) (bool, error) {
 func (b *RoundState) SetPreCommit(v *PreCommit) (bool, error) {
 	if IsDeadBlockRound(v) {
 		if len(v.Proposal.TxHshLst) != 0 {
-			return false, errorz.ErrInvalid{}.New("dbr tx hash in set pc")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreCommit; dbr tx hash in set pc")
 		}
 	}
 	ok, err := b.genericSet(v)
@@ -530,7 +536,7 @@ func (b *RoundState) SetPreCommit(v *PreCommit) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt pc in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreCommit; corrupt pc in dbr")
 		}
 	}
 	return ok, nil
@@ -538,7 +544,7 @@ func (b *RoundState) SetPreCommit(v *PreCommit) (bool, error) {
 
 func (b *RoundState) SetPreCommitNil(v *PreCommitNil) (bool, error) {
 	if IsDeadBlockRound(v) {
-		return false, errorz.ErrInvalid{}.New("dbr tx hash in pcn")
+		return false, errorz.ErrInvalid{}.New("RoundState.SetPreCommitNil; dbr tx hash in pcn")
 	}
 	ok, err := b.genericSet(v)
 	if err != nil {
@@ -546,7 +552,7 @@ func (b *RoundState) SetPreCommitNil(v *PreCommitNil) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt pcn in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetPreCommitNil; corrupt pcn in dbr")
 		}
 	}
 	return ok, nil
@@ -554,7 +560,7 @@ func (b *RoundState) SetPreCommitNil(v *PreCommitNil) (bool, error) {
 
 func (b *RoundState) SetNextRound(v *NextRound) (bool, error) {
 	if IsDeadBlockRound(v) {
-		return false, errorz.ErrInvalid{}.New("nr in dbr")
+		return false, errorz.ErrInvalid{}.New("RoundState.SetNextRound; nr in dbr")
 	}
 	ok, err := b.genericSet(v)
 	if err != nil {
@@ -562,7 +568,7 @@ func (b *RoundState) SetNextRound(v *NextRound) (bool, error) {
 	}
 	if !ok {
 		if IsDeadBlockRound(v) {
-			return false, errorz.ErrInvalid{}.New("corrupt nr in dbr")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetNextRound; corrupt nr in dbr")
 		}
 	}
 	return ok, nil
@@ -571,12 +577,12 @@ func (b *RoundState) SetNextRound(v *NextRound) (bool, error) {
 func (b *RoundState) SetNextHeight(v *NextHeight) (bool, error) {
 	if IsDeadBlockRound(v) {
 		if len(v.NHClaims.Proposal.TxHshLst) != 0 {
-			return false, errorz.ErrInvalid{}.New("set nh dbr tx hash")
+			return false, errorz.ErrInvalid{}.New("RoundState.SetNextHeight; set nh dbr tx hash")
 		}
 	}
 	relationH := RelateH(b, v)
 	if relationH == 1 { // from prev height
-		return false, errorz.ErrStale{}.New("set nh relation == 1")
+		return false, errorz.ErrStale{}.New("RoundState.SetNextHeight; set nh relation == 1")
 	}
 	if relationH == -1 { // from future height
 		b.setReset(v)
@@ -594,7 +600,7 @@ func (b *RoundState) SetNextHeight(v *NextHeight) (bool, error) {
 func (b *RoundState) genericSet(v interface{}) (bool, error) {
 	relationH := RelateH(b, v)
 	if relationH == 1 { // from prev height
-		return false, errorz.ErrStale{}.New("generic set: relationH == 1")
+		return false, errorz.ErrStale{}.New("RoundState.genericSet; relationH == 1")
 	}
 	if relationH == -1 { // from future height
 		b.setReset(v)
@@ -608,11 +614,11 @@ func (b *RoundState) genericSet(v interface{}) (bool, error) {
 		case *NextHeight:
 			if b.NextHeight != nil {
 				if RelateHR(b.NextHeight, v) != -1 {
-					return false, errorz.ErrStale{}.New("stale next height")
+					return false, errorz.ErrStale{}.New("RoundState.genericSet; stale next height")
 				}
 			}
 		default:
-			return false, errorz.ErrStale{}.New("generic set: relationHR == 1")
+			return false, errorz.ErrStale{}.New("RoundState.genericSet; relationHR == 1")
 		}
 	}
 	if relationHR == -1 { // from future round
@@ -673,7 +679,7 @@ func (b *RoundState) checkConflict(a interface{}, internal bool) error {
 	case *NextHeight:
 		hasBClaims = true
 	default:
-		panic("bad type in hash bclaims check")
+		panic("RoundState.checkConflict; bad type in hash bclaims check")
 	}
 	if b.Proposal != nil && hasBClaims {
 		ok, err := BClaimsEqual(a, b.Proposal)
@@ -749,49 +755,49 @@ func (b *RoundState) resetNHForDBR(v interface{}) {
 
 func (b *RoundState) checkSameTypeConflict(any interface{}) error {
 	if b.ImplicitPVN || b.ImplicitPCN {
-		return errorz.ErrInvalid{}.New("pvn or pcn implicit nil set")
+		return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pvn or pcn implicit nil set")
 	}
 	if b.ConflictingRCert != nil {
-		return errorz.ErrInvalid{}.New("conflicting rc")
+		return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; conflicting rc")
 	}
 	switch any.(type) {
 	case *Proposal:
 		if b.ConflictingProposal != nil {
-			return errorz.ErrInvalid{}.New("conflicting p set")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; conflicting p set")
 		}
 	case *PreVote:
 		if b.PreVoteNil != nil {
-			return errorz.ErrInvalid{}.New("conflicting pvn set")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; conflicting pvn set")
 		}
 		if b.ConflictingPreVote != nil {
-			return errorz.ErrInvalid{}.New("conflicting pv set")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; conflicting pv set")
 		}
 	case *PreVoteNil:
 		if b.PreVote != nil {
-			return errorz.ErrInvalid{}.New("pv and pvn")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pv and pvn")
 		}
 	case *PreCommit:
 		if b.PreVoteNil != nil {
-			return errorz.ErrInvalid{}.New("pc and pvn")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pc and pvn")
 		}
 		if b.PreCommitNil != nil {
-			return errorz.ErrInvalid{}.New("pc and pcn")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pc and pcn")
 		}
 		if b.ConflictingPreCommit != nil {
-			return errorz.ErrInvalid{}.New("pc and conflicting pc set")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pc and conflicting pc set")
 		}
 	case *PreCommitNil:
 		if b.PreCommit != nil {
-			return errorz.ErrInvalid{}.New("pc and pcn on nil side")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; pc and pcn on nil side")
 		}
 	case *NextRound:
 	// check rcert done above
 	case *NextHeight:
 		if b.ConflictingNextHeight != nil {
-			return errorz.ErrInvalid{}.New("nh conflicting set")
+			return errorz.ErrInvalid{}.New("RoundState.checkSameTypeConflict; nh conflicting set")
 		}
 	default:
-		panic("bad type in check same conflict")
+		panic("RoundState.checkSameTypeConflict; bad type in check same conflict")
 	}
 	return nil
 }
@@ -845,7 +851,7 @@ func (b *RoundState) setReset(any interface{}) {
 			b.ConflictingNextHeight = nil
 		}
 	default:
-		panic("bad type in set type")
+		panic("RoundState.setReset; bad type in set type")
 	}
 	b.Reset()
 	b.setType(ExtractRCert(any))
@@ -870,7 +876,7 @@ func (b *RoundState) setTypeConflict(any interface{}, internal bool) {
 		case *NextHeight:
 			b.ConflictingNextHeight = v
 		default:
-			panic("bad type in set conflict")
+			panic("RoundState.setTypeConflict; bad type in set conflict")
 		}
 	}
 	b.ImplicitPVN = true
@@ -896,7 +902,7 @@ func (b *RoundState) setType(any interface{}) {
 	case *NextHeight:
 		b.NextHeight = v
 	default:
-		panic("bad type in set type")
+		panic("RoundState.setType; bad type in set type")
 	}
 }
 
@@ -907,34 +913,34 @@ func (b *RoundState) checkTypeStale(any interface{}, internal bool) error {
 	switch any.(type) {
 	case *Proposal:
 		if b.Proposal != nil {
-			return errorz.ErrStale{}.New("prop already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; prop already set")
 		}
 	case *PreVote:
 		if b.PreVote != nil {
-			return errorz.ErrStale{}.New("pv already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; pv already set")
 		}
 	case *PreVoteNil:
 		if b.PreVoteNil != nil {
-			return errorz.ErrStale{}.New("pvn already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; pvn already set")
 		}
 	case *PreCommit:
 		if b.PreCommit != nil {
-			return errorz.ErrStale{}.New("pc already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; pc already set")
 		}
 	case *PreCommitNil:
 		if b.PreCommitNil != nil {
-			return errorz.ErrStale{}.New("pcn already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; pcn already set")
 		}
 	case *NextHeight:
 		if b.NextHeight != nil {
-			return errorz.ErrStale{}.New("nh already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; nh already set")
 		}
 	case *NextRound:
 		if b.NextRound != nil {
-			return errorz.ErrStale{}.New("nr already set")
+			return errorz.ErrStale{}.New("RoundState.checkTypeStale; nr already set")
 		}
 	default:
-		panic("bad type in check stale")
+		panic("RoundState.checkTypeStale; bad type in check stale")
 	}
 	return nil
 }

--- a/consensus/objs/rskeycurr.go
+++ b/consensus/objs/rskeycurr.go
@@ -22,7 +22,7 @@ type RoundStateCurrentKey struct {
 // the canonical byte slice
 func (b *RoundStateCurrentKey) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("RoundStateCurrentKey.MarshalBinary; rsck not initialized")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)
@@ -42,7 +42,7 @@ func (b *RoundStateCurrentKey) MarshalBinary() ([]byte, error) {
 // RoundStateCurrentKey object
 func (b *RoundStateCurrentKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("RoundStateCurrentKey.UnmarshalBinary; rsck not initialized")
 	}
 	splitData := bytes.Split(data, []byte("|"))
 	if len(splitData) != 3 {

--- a/consensus/objs/safetoproceedkey.go
+++ b/consensus/objs/safetoproceedkey.go
@@ -16,8 +16,11 @@ type SafeToProceedKey struct {
 // MarshalBinary takes the SafeToProceedKey object and returns
 // the canonical byte slice
 func (b *SafeToProceedKey) MarshalBinary() ([]byte, error) {
-	if b == nil || b.Height == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("SafeToProceedKey.MarshalBinary; stpk not initialized")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("SafeToProceedKey.MarshalBinary; height is zero")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)
@@ -33,7 +36,7 @@ func (b *SafeToProceedKey) MarshalBinary() ([]byte, error) {
 // SafeToProceedKey object
 func (b *SafeToProceedKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("SafeToProceedKey.UnmarshalBinary; stpk not initialized")
 	}
 	splitData := bytes.Split(data, []byte("|"))
 	if len(splitData) != 3 {
@@ -45,10 +48,10 @@ func (b *SafeToProceedKey) UnmarshalBinary(data []byte) error {
 		return err
 	}
 	if Height == 0 {
-		return errorz.ErrInvalid{}.New("invalid height for unmarshalling")
+		return errorz.ErrInvalid{}.New("SafeToProceedKey.UnmarshalBinary; height is zero")
 	}
 	if len(splitData[2]) != 0 {
-		return errorz.ErrInvalid{}.New("invalid SafeToProceedKey")
+		return errorz.ErrInvalid{}.New("SafeToProceedKey.UnmarshalBinary; invalid key")
 	}
 	b.Height = Height
 	return nil

--- a/consensus/objs/sbhkey.go
+++ b/consensus/objs/sbhkey.go
@@ -15,10 +15,10 @@ type StagedBlockHeaderKey struct {
 // StagedBlockHeaderKey object
 func (b *StagedBlockHeaderKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("StagedBlockHeaderKey.UnmarshalBinary; sbhk not initialized")
 	}
 	if len(data) != 6 {
-		return errorz.ErrInvalid{}.New("Invalid data for StagedBlockHeaderKey unmarshalling")
+		return errorz.ErrInvalid{}.New("StagedBlockHeaderKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	b.Key = utils.CopySlice(data[2:])
@@ -28,8 +28,14 @@ func (b *StagedBlockHeaderKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the StagedBlockHeaderKey object and returns the canonical
 // byte slice
 func (b *StagedBlockHeaderKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || len(b.Key) != 4 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("StagedBlockHeaderKey.MarshalBinary; sbhk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("StagedBlockHeaderKey.MarshalBinary; incorrect prefix length")
+	}
+	if len(b.Key) != 4 {
+		return nil, errorz.ErrInvalid{}.New("StagedBlockHeaderKey.MarshalBinary; incorrect key length")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)

--- a/consensus/objs/txcachekey.go
+++ b/consensus/objs/txcachekey.go
@@ -18,8 +18,14 @@ type TxCacheKey struct {
 // MarshalBinary takes the TxCacheKey object and returns
 // the canonical byte slice
 func (b *TxCacheKey) MarshalBinary() ([]byte, error) {
-	if b == nil || b.Height == 0 || len(b.TxHash) != constants.HashLen {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("TxCacheKey.MarshalBinary; tck not initialized")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("TxCacheKey.MarshalBinary; height is zero")
+	}
+	if len(b.TxHash) != constants.HashLen {
+		return nil, errorz.ErrInvalid{}.New("TxCacheKey.MarshalBinary; incorrect txhash length")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)
@@ -37,7 +43,7 @@ func (b *TxCacheKey) MarshalBinary() ([]byte, error) {
 // TxCacheKey object
 func (b *TxCacheKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("TxCacheKey.UnmarshalBinary; tck not initialized")
 	}
 	splitData := bytes.Split(data, []byte("|"))
 	if len(splitData) != 3 {
@@ -49,12 +55,12 @@ func (b *TxCacheKey) UnmarshalBinary(data []byte) error {
 		return err
 	}
 	if Height == 0 {
-		return errorz.ErrInvalid{}.New("invalid height for unmarshalling")
+		return errorz.ErrInvalid{}.New("TxCacheKey.UnmarshalBinary; height is zero")
 	}
 	b.Height = Height
 	TxHash := utils.CopySlice(splitData[2])
 	if len(TxHash) != constants.HashLen {
-		return errorz.ErrInvalid{}.New("invalid txhash for unmarshalling; incorrect length")
+		return errorz.ErrInvalid{}.New("TxCacheKey.UnmarshalBinary; incorrect txhash length")
 	}
 	b.TxHash = TxHash
 	return nil
@@ -62,8 +68,11 @@ func (b *TxCacheKey) UnmarshalBinary(data []byte) error {
 
 // MakeIterKey ...
 func (b *TxCacheKey) MakeIterKey() ([]byte, error) {
-	if b == nil || b.Height == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("TxCacheKey.MakeIterKey; tck not initialized")
+	}
+	if b.Height == 0 {
+		return nil, errorz.ErrInvalid{}.New("TxCacheKey.MakeIterKey; height is zero")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)

--- a/consensus/objs/util.go
+++ b/consensus/objs/util.go
@@ -63,7 +63,7 @@ func ExtractHR(any interface{}) (uint32, uint32) {
 		rc := v
 		return rc.Height, 1
 	default:
-		panic(fmt.Sprintf("undefined type in ExtractHR %T", v))
+		panic(fmt.Sprintf("ExtractHR; undefined type %T", v))
 	}
 }
 
@@ -102,7 +102,7 @@ func ExtractHCID(any interface{}) (uint32, uint32) {
 		rc := v
 		return rc.Height, rc.ChainID
 	default:
-		panic(fmt.Sprintf("undefined type in ExtractHCID %T", v))
+		panic(fmt.Sprintf("ExtractHCID; undefined type %T", v))
 	}
 }
 
@@ -158,7 +158,7 @@ func ExtractRCert(any interface{}) *RCert {
 		rc := v.NHClaims.Proposal.PClaims.RCert
 		return rc
 	default:
-		panic(fmt.Sprintf("undefined type in ExtractRCert %T", v))
+		panic(fmt.Sprintf("ExtractRCert; undefined type %T", v))
 	}
 }
 
@@ -259,7 +259,7 @@ func ExtractBClaims(any interface{}) *BClaims {
 	case *NextHeight:
 		return v.NHClaims.Proposal.PClaims.BClaims
 	default:
-		panic(fmt.Sprintf("undefined type in ExtractBClaims %T", v))
+		panic(fmt.Sprintf("ExtractBClaims; undefined type %T", v))
 	}
 }
 
@@ -285,7 +285,7 @@ func MakeTxRoot(txHashes [][]byte) ([]byte, error) {
 	for i := 0; i < len(txHashes); i++ {
 		txHash := txHashes[i]
 		if len(txHash) != constants.HashLen {
-			return nil, errorz.ErrInvalid{}.New("incorrect txHash length")
+			return nil, errorz.ErrInvalid{}.New("MakeTxRoot; incorrect txHash length")
 		}
 		values = append(values, crypto.Hasher(txHash))
 	}
@@ -311,8 +311,11 @@ func GetProposerIdx(numv int, height uint32, round uint32) uint8 {
 
 // SplitBlob separates a blob of fixed size data types into a slice of slices
 func SplitBlob(s []byte, blen int) ([][]byte, error) {
+	if blen <= 0 {
+		return [][]byte{}, errorz.ErrInvalid{}.New("SplitBlob; blen <= 0")
+	}
 	if len(s)%blen != 0 {
-		return [][]byte{}, errorz.ErrInvalid{}.New("split blob length is not modulo length")
+		return [][]byte{}, errorz.ErrInvalid{}.New("SplitBlob; invalid length")
 	}
 	buf := [][]byte{}
 	for i := 0; i < len(s)/blen; i++ {

--- a/consensus/objs/v.go
+++ b/consensus/objs/v.go
@@ -17,6 +17,9 @@ type Validator struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // Validator object
 func (b *Validator) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Validator.UnmarshalBinary; validator not initialized")
+	}
 	bh, err := validator.Unmarshal(data)
 	if err != nil {
 		return err
@@ -27,6 +30,9 @@ func (b *Validator) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *Validator) UnmarshalCapn(bh mdefs.Validator) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("Validator.UnmarshalCapn; validator not initialized")
+	}
 	err := validator.Validate(bh)
 	if err != nil {
 		return err
@@ -40,7 +46,7 @@ func (b *Validator) UnmarshalCapn(bh mdefs.Validator) error {
 // byte slice
 func (b *Validator) MarshalBinary() ([]byte, error) {
 	if b == nil {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+		return nil, errorz.ErrInvalid{}.New("Validator.MarshalBinary; validator not initialized")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -53,7 +59,7 @@ func (b *Validator) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *Validator) MarshalCapn(seg *capnp.Segment) (mdefs.Validator, error) {
 	if b == nil {
-		return mdefs.Validator{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.Validator{}, errorz.ErrInvalid{}.New("Validator.MarshalCapn; validator not initialized")
 	}
 	var bh mdefs.Validator
 	if seg == nil {

--- a/consensus/objs/vs.go
+++ b/consensus/objs/vs.go
@@ -25,6 +25,9 @@ type ValidatorSet struct {
 // UnmarshalBinary takes a byte slice and returns the corresponding
 // ValidatorSet object
 func (b *ValidatorSet) UnmarshalBinary(data []byte) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("ValidatorSet.UnmarshalBinary; vs not initialized")
+	}
 	bh, err := vset.Unmarshal(data)
 	if err != nil {
 		return err
@@ -35,6 +38,9 @@ func (b *ValidatorSet) UnmarshalBinary(data []byte) error {
 
 // UnmarshalCapn unmarshals the capnproto definition of the object
 func (b *ValidatorSet) UnmarshalCapn(bh mdefs.ValidatorSet) error {
+	if b == nil {
+		return errorz.ErrInvalid{}.New("ValidatorSet.UnmarshalCapn; vs not initialized")
+	}
 	err := vset.Validate(bh)
 	if err != nil {
 		return err
@@ -69,8 +75,11 @@ func (b *ValidatorSet) UnmarshalCapn(bh mdefs.ValidatorSet) error {
 // MarshalBinary takes the ValidatorSet object and returns the canonical
 // byte slice
 func (b *ValidatorSet) MarshalBinary() ([]byte, error) {
-	if b == nil || b.NotBefore == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("ValidatorSet.MarshalBinary; vs not initialized")
+	}
+	if b.NotBefore == 0 {
+		return nil, errorz.ErrInvalid{}.New("ValidatorSet.MarshalBinary; NotBefore is zero")
 	}
 	bh, err := b.MarshalCapn(nil)
 	if err != nil {
@@ -83,7 +92,7 @@ func (b *ValidatorSet) MarshalBinary() ([]byte, error) {
 // MarshalCapn marshals the object into its capnproto definition
 func (b *ValidatorSet) MarshalCapn(seg *capnp.Segment) (mdefs.ValidatorSet, error) {
 	if b == nil {
-		return mdefs.ValidatorSet{}, errorz.ErrInvalid{}.New("not initialized")
+		return mdefs.ValidatorSet{}, errorz.ErrInvalid{}.New("ValidatorSet.MarshalCapn; vs not initialized")
 	}
 	var bh mdefs.ValidatorSet
 	if seg == nil {

--- a/consensus/objs/vskey.go
+++ b/consensus/objs/vskey.go
@@ -15,15 +15,15 @@ type ValidatorSetKey struct {
 // ValidatorSetKey object
 func (b *ValidatorSetKey) UnmarshalBinary(data []byte) error {
 	if b == nil {
-		return errorz.ErrInvalid{}.New("not initialized")
+		return errorz.ErrInvalid{}.New("ValidatorSetKey.UnmarshalBinary; vsk not initialized")
 	}
 	if len(data) != 6 {
-		return errorz.ErrInvalid{}.New("data incorrect length for unmarshalling ValidatorSetKey")
+		return errorz.ErrInvalid{}.New("ValidatorSetKey.UnmarshalBinary; incorrect data length")
 	}
 	b.Prefix = utils.CopySlice(data[0:2])
 	nb, _ := utils.UnmarshalUint32(data[2:6])
 	if nb == 0 {
-		return errorz.ErrInvalid{}.New("invalid NotBefore for unmarshalling ValidatorSetKey; NotBefore == 0")
+		return errorz.ErrInvalid{}.New("ValidatorSetKey.UnmarshalBinary; NotBefore is zero")
 	}
 	b.NotBefore = nb
 	return nil
@@ -32,8 +32,14 @@ func (b *ValidatorSetKey) UnmarshalBinary(data []byte) error {
 // MarshalBinary takes the ValidatorSetKey object and returns the canonical
 // byte slice
 func (b *ValidatorSetKey) MarshalBinary() ([]byte, error) {
-	if b == nil || len(b.Prefix) != 2 || b.NotBefore == 0 {
-		return nil, errorz.ErrInvalid{}.New("not initialized")
+	if b == nil {
+		return nil, errorz.ErrInvalid{}.New("ValidatorSetKey.MarshalBinary; vsk not initialized")
+	}
+	if len(b.Prefix) != 2 {
+		return nil, errorz.ErrInvalid{}.New("ValidatorSetKey.MarshalBinary; incorrect prefix length")
+	}
+	if b.NotBefore == 0 {
+		return nil, errorz.ErrInvalid{}.New("ValidatorSetKey.MarshalBinary; NotBefore is zero")
 	}
 	key := []byte{}
 	Prefix := utils.CopySlice(b.Prefix)


### PR DESCRIPTION
## Scope

Updated error messages in consensus/objects.

## Why?

This will make it easier to track error propagation.

## Todos

Better tests should be added to consensus objects to ensure correct behavior.