### PR TITLE
Add solidity linter

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -31,5 +31,3 @@ bindings-artifacts/*
 bindings/generate.go
 !deployments/dev/deploymentArgsTemplate.json
 !deployments/dev/deployList.json
-# deployments/dev/archive/
-# deployments/dev/

--- a/bridge/.solhint.json
+++ b/bridge/.solhint.json
@@ -3,8 +3,28 @@
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": "error",
-    "reason-string": ["warn", { "maxLength": 80 }],
+    "max-states-count": ["warn", 20],
+    "no-empty-blocks": "off",
+    "no-unused-vars": "warn",
+    "payable-fallback": "warn",
+    "reason-string": ["warn", {"maxLength": 100}],
+    "quotes": ["warn","double"],
+    "const-name-snakecase": "warn",
+    "contract-name-camelcase": "warn",
+    "event-name-camelcase": "warn",
+    "func-name-mixedcase": "warn",
+    "func-param-name-mixedcase": "warn",
+    "modifier-name-mixedcase": "warn",
+    "private-vars-leading-underscore": "warn",
+    "use-forbidden-name": "warn",
+    "var-name-mixedcase": "warn",
+    "imports-on-top": "warn",
+    "ordering": "warn",
+    "visibility-modifier-order": "warn",
+    "func-visibility": ["warn", {"ignoreConstructors": true}],
     "compiler-version": "off",
-    "no-inline-assembly": "off"
+    "no-inline-assembly": "off",
+    "avoid-low-level-calls": "off",
+    "no-complex-fallback": "off"
   }
 }

--- a/bridge/contracts/MadToken.sol
+++ b/bridge/contracts/MadToken.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "contracts/utils/Admin.sol";
 
 abstract contract MadTokenBase is ERC20Upgradeable, Admin {
-    function __MadTokenBase_init() internal onlyInitializing {
+    function __madTokenBaseInit() internal onlyInitializing {
         __ERC20_init("MadToken", "MT");
     }
 }
@@ -21,7 +21,7 @@ contract MadToken is MadTokenBase {
     constructor() Admin(msg.sender) {}
 
     function initialize(address owner_) public onlyAdmin initializer {
-        __MadTokenBase_init();
+        __madTokenBaseInit();
         _mint(owner_, 220000000 * 10**decimals());
     }
 

--- a/bridge/contracts/Proxy.sol
+++ b/bridge/contracts/Proxy.sol
@@ -27,7 +27,6 @@ contract Proxy {
         _factory = msg.sender;
     }
 
-    //todo: discuss with Hunter
     receive() external payable {
         _fallback();
     }

--- a/bridge/contracts/Proxy.sol
+++ b/bridge/contracts/Proxy.sol
@@ -21,10 +21,19 @@ import "contracts/utils/DeterministicAddress.sol";
  * the higher order bits to lock the upgrade capability of the proxy.
  */
 contract Proxy {
-    address private immutable factory_;
+    address private immutable _factory;
 
     constructor() {
-        factory_ = msg.sender;
+        _factory = msg.sender;
+    }
+
+    //todo: discuss with Hunter
+    receive() external payable {
+        _fallback();
+    }
+
+    fallback() external payable {
+        _fallback();
     }
 
     function getImplementationAddress() public view returns (address) {
@@ -40,10 +49,10 @@ contract Proxy {
         }
     }
 
-    fallback() external payable {
+    function _fallback() internal {
         // make local copy of factory since immutables
         // are not accessable in assembly as of yet
-        address factory = factory_;
+        address factory = _factory;
         assembly {
             // admin is the builtin logic to change the implementation
             function admin() {

--- a/bridge/contracts/Snapshots.sol
+++ b/bridge/contracts/Snapshots.sol
@@ -29,76 +29,8 @@ contract Snapshots is Initializable, SnapshotsStorage, ISnapshots {
         _snapshotDesperationDelay = desperationDelay_;
     }
 
-    function getSnapshotDesperationDelay() public view returns (uint256) {
-        return _snapshotDesperationDelay;
-    }
-
     function setSnapshotDesperationFactor(uint32 desperationFactor_) public onlyFactory {
         _snapshotDesperationFactor = desperationFactor_;
-    }
-
-    function getSnapshotDesperationFactor() public view returns (uint256) {
-        return _snapshotDesperationFactor;
-    }
-
-    function getChainId() public view returns (uint256) {
-        return _chainId;
-    }
-
-    function getEpoch() public view returns (uint256) {
-        return _epoch;
-    }
-
-    function getEpochLength() public view returns (uint256) {
-        return _epochLength;
-    }
-
-    function getChainIdFromSnapshot(uint256 epoch_) public view returns (uint256) {
-        return _snapshots[epoch_].blockClaims.chainId;
-    }
-
-    function getChainIdFromLatestSnapshot() public view returns (uint256) {
-        return _snapshots[_epoch].blockClaims.chainId;
-    }
-
-    function getBlockClaimsFromSnapshot(uint256 epoch_)
-        public
-        view
-        returns (BClaimsParserLibrary.BClaims memory)
-    {
-        return _snapshots[epoch_].blockClaims;
-    }
-
-    function getBlockClaimsFromLatestSnapshot()
-        public
-        view
-        returns (BClaimsParserLibrary.BClaims memory)
-    {
-        return _snapshots[_epoch].blockClaims;
-    }
-
-    function getCommittedHeightFromSnapshot(uint256 epoch_) public view returns (uint256) {
-        return _snapshots[epoch_].committedAt;
-    }
-
-    function getCommittedHeightFromLatestSnapshot() public view returns (uint256) {
-        return _snapshots[_epoch].committedAt;
-    }
-
-    function getMadnetHeightFromSnapshot(uint256 epoch_) public view returns (uint256) {
-        return _snapshots[epoch_].blockClaims.height;
-    }
-
-    function getMadnetHeightFromLatestSnapshot() public view returns (uint256) {
-        return _snapshots[_epoch].blockClaims.height;
-    }
-
-    function getSnapshot(uint256 epoch_) public view returns (Snapshot memory) {
-        return _snapshots[epoch_];
-    }
-
-    function getLatestSnapshot() public view returns (Snapshot memory) {
-        return _snapshots[_epoch];
     }
 
     /// @notice Saves next snapshot
@@ -121,6 +53,8 @@ contract Snapshots is Initializable, SnapshotsStorage, ISnapshots {
         (bool success, uint256 validatorIndex) = IETHDKG(_ETHDKGAddress()).tryGetParticipantIndex(
             msg.sender
         );
+        //todo:remove this, dummy operation only to silence linter
+        validatorIndex;
         require(success, "Snapshots: Caller didn't participate in the last ethdkg round!");
         // todo: critical! add eth min blocks between snapshots
 
@@ -200,6 +134,74 @@ contract Snapshots is Initializable, SnapshotsStorage, ISnapshots {
             groupSignature_
         );
         return isSafeToProceedConsensus;
+    }
+
+    function getSnapshotDesperationFactor() public view returns (uint256) {
+        return _snapshotDesperationFactor;
+    }
+
+    function getSnapshotDesperationDelay() public view returns (uint256) {
+        return _snapshotDesperationDelay;
+    }
+
+    function getChainId() public view returns (uint256) {
+        return _chainId;
+    }
+
+    function getEpoch() public view returns (uint256) {
+        return _epoch;
+    }
+
+    function getEpochLength() public view returns (uint256) {
+        return _epochLength;
+    }
+
+    function getChainIdFromSnapshot(uint256 epoch_) public view returns (uint256) {
+        return _snapshots[epoch_].blockClaims.chainId;
+    }
+
+    function getChainIdFromLatestSnapshot() public view returns (uint256) {
+        return _snapshots[_epoch].blockClaims.chainId;
+    }
+
+    function getBlockClaimsFromSnapshot(uint256 epoch_)
+        public
+        view
+        returns (BClaimsParserLibrary.BClaims memory)
+    {
+        return _snapshots[epoch_].blockClaims;
+    }
+
+    function getBlockClaimsFromLatestSnapshot()
+        public
+        view
+        returns (BClaimsParserLibrary.BClaims memory)
+    {
+        return _snapshots[_epoch].blockClaims;
+    }
+
+    function getCommittedHeightFromSnapshot(uint256 epoch_) public view returns (uint256) {
+        return _snapshots[epoch_].committedAt;
+    }
+
+    function getCommittedHeightFromLatestSnapshot() public view returns (uint256) {
+        return _snapshots[_epoch].committedAt;
+    }
+
+    function getMadnetHeightFromSnapshot(uint256 epoch_) public view returns (uint256) {
+        return _snapshots[epoch_].blockClaims.height;
+    }
+
+    function getMadnetHeightFromLatestSnapshot() public view returns (uint256) {
+        return _snapshots[_epoch].blockClaims.height;
+    }
+
+    function getSnapshot(uint256 epoch_) public view returns (Snapshot memory) {
+        return _snapshots[epoch_];
+    }
+
+    function getLatestSnapshot() public view returns (Snapshot memory) {
+        return _snapshots[_epoch];
     }
 
     function mayValidatorSnapshot(

--- a/bridge/contracts/StakeNFT.sol
+++ b/bridge/contracts/StakeNFT.sol
@@ -12,15 +12,6 @@ import "contracts/interfaces/ICBOpener.sol";
 import "contracts/interfaces/INFTStake.sol";
 
 abstract contract StakeNFTStorage {
-    // _MAX_MINT_LOCK describes the maximum interval a Position may be locked
-    // during a call to mintTo
-    uint256 internal constant _MAX_MINT_LOCK = 1051200;
-    // 10**18
-    uint256 internal constant _ACCUMULATOR_SCALE_FACTOR = 1000000000000000000;
-    // constants for the cb state
-    bool internal constant CIRCUIT_BREAKER_OPENED = true;
-    bool internal constant CIRCUIT_BREAKER_CLOSED = false;
-
     // Position describes a staked position
     struct Position {
         // number of madToken
@@ -46,6 +37,15 @@ abstract contract StakeNFTStorage {
         // slush stores division remainders until they may be distributed evenly
         uint256 slush;
     }
+
+    // _MAX_MINT_LOCK describes the maximum interval a Position may be locked
+    // during a call to mintTo
+    uint256 internal constant _MAX_MINT_LOCK = 1051200;
+    // 10**18
+    uint256 internal constant _ACCUMULATOR_SCALE_FACTOR = 1000000000000000000;
+    // constants for the cb state
+    bool internal constant _CIRCUIT_BREAKER_OPENED = true;
+    bool internal constant _CIRCUIT_BREAKER_CLOSED = false;
 
     // monotonically increasing counter
     uint256 internal _counter;
@@ -92,93 +92,33 @@ abstract contract StakeNFTBase is
     ImmutableMadToken,
     ImmutableGovernance
 {
-    constructor()
-        ImmutableFactory(msg.sender)
-        ImmutableMadToken()
-        ImmutableGovernance()
-        ImmutableValidatorPool()
-    {
-        //IERC20Transferable(_MadTokenAddress())
-        //IERC20Transferable(_GovernanceAddress())
-        // _madToken = IERC20Transferable(getMetamorphicContractAddress(0x4d6164546f6b656e000000000000000000000000000000000000000000000000, _factory));
-        // _governance = getMetamorphicContractAddress(0x476f7665726e616e636500000000000000000000000000000000000000000000, _factory);
-    }
-
-    function __StakeNFTBase_init(string memory name_, string memory symbol_)
-        internal
-        onlyInitializing
-    {
-        __ERC721_init(name_, symbol_);
-    }
-
     // withCircuitBreaker is a modifier to enforce the CircuitBreaker must
     // be set for a call to succeed
     modifier withCircuitBreaker() {
         require(
-            _circuitBreaker == CIRCUIT_BREAKER_CLOSED,
+            _circuitBreaker == _CIRCUIT_BREAKER_CLOSED,
             "CircuitBreaker: The Circuit breaker is opened!"
         );
         _;
     }
 
-    // function isAllowedProposal(address addr) public view returns(bool) {
-    //     return _isAllowedProposal(addr);
-    // }
+    constructor()
+        ImmutableFactory(msg.sender)
+        ImmutableMadToken()
+        ImmutableGovernance()
+        ImmutableValidatorPool()
+    {}
 
-    function circuitBreakerState() public view returns (bool) {
-        return _circuitBreaker;
+    /// gets the current value for the Eth accumulator
+    function getEthAccumulator() external view returns (uint256 accumulator, uint256 slush) {
+        accumulator = _ethState.accumulator;
+        slush = _ethState.slush;
     }
 
-    /// gets the _ACCUMULATOR_SCALE_FACTOR used to scale the ether and tokens
-    /// deposited on this contract to reduce the integer division errors.
-    function getAccumulatorScaleFactor() public pure returns (uint256) {
-        return _ACCUMULATOR_SCALE_FACTOR;
-    }
-
-    /// gets the total amount of MadToken staked in contract
-    function getTotalShares() public view returns (uint256) {
-        return _shares;
-    }
-
-    /// gets the total amount of Ether staked in contract
-    function getTotalReserveEth() public view returns (uint256) {
-        return _reserveEth;
-    }
-
-    /// gets the total amount of MadToken staked in contract
-    function getTotalReserveMadToken() public view returns (uint256) {
-        return _reserveToken;
-    }
-
-    /// estimateEthCollection returns the amount of eth a tokenID may withdraw
-    function estimateEthCollection(uint256 tokenID_) public view returns (uint256 payout) {
-        require(_exists(tokenID_), "StakeNFT: Error, NFT token doesn't exist!");
-        Position memory p = _positions[tokenID_];
-        (, , , payout) = _collect(_shares, _ethState, p, p.accumulatorEth);
-        return payout;
-    }
-
-    /// estimateTokenCollection returns the amount of MadToken a tokenID may withdraw
-    function estimateTokenCollection(uint256 tokenID_) public view returns (uint256 payout) {
-        require(_exists(tokenID_), "StakeNFT: Error, NFT token doesn't exist!");
-        Position memory p = _positions[tokenID_];
-        (, , , payout) = _collect(_shares, _tokenState, p, p.accumulatorToken);
-        return payout;
-    }
-
-    /// estimateExcessToken returns the amount of MadToken that is held in the
-    /// name of this contract. The value returned is the value that would be
-    /// returned by a call to skimExcessToken.
-    function estimateExcessToken() public view returns (uint256 excess) {
-        (, excess) = _estimateExcessToken();
-        return excess;
-    }
-
-    /// estimateExcessEth returns the amount of Eth that is held in the name of
-    /// this contract. The value returned is the value that would be returned by
-    /// a call to skimExcessEth.
-    function estimateExcessEth() public view returns (uint256 excess) {
-        return _estimateExcessEth();
+    /// gets the current value for the Token accumulator
+    function getTokenAccumulator() external view returns (uint256 accumulator, uint256 slush) {
+        accumulator = _tokenState.accumulator;
+        slush = _tokenState.slush;
     }
 
     /// @dev tripCB opens the circuit breaker may only be called by _admin
@@ -205,15 +145,15 @@ abstract contract StakeNFTBase is
     /// this contract in error by a user. This method can not return any funds
     /// sent to the contract via the depositToken method.
     function skimExcessToken(address to_) public onlyFactory returns (uint256 excess) {
-        IERC20Transferable MadToken;
-        (MadToken, excess) = _estimateExcessToken();
-        _safeTransferERC20(MadToken, to_, excess);
+        IERC20Transferable madToken;
+        (madToken, excess) = _estimateExcessToken();
+        _safeTransferERC20(madToken, to_, excess);
         return excess;
     }
 
     /// lockPosition is called by governance system when a governance
     /// vote is cast. This function will lock the specified Position for up to
-    /// _maxGovernanceLock. This method may only be called by the governance
+    /// _MAX_GOVERNANCE_LOCK. This method may only be called by the governance
     /// contract. This function will fail if the circuit breaker is tripped
     function lockPosition(
         address caller_,
@@ -225,13 +165,13 @@ abstract contract StakeNFTBase is
             "StakeNFT: Error, token doesn't exist or doesn't belong to the caller!"
         );
         require(
-            lockDuration_ <= _maxGovernanceLock,
+            lockDuration_ <= _MAX_GOVERNANCE_LOCK,
             "StakeNFT: Lock Duration is greater than the amount allowed!"
         );
         return _lockPosition(tokenID_, lockDuration_);
     }
 
-    /// This function will lock an owned Position for up to _maxGovernanceLock. This method may
+    /// This function will lock an owned Position for up to _MAX_GOVERNANCE_LOCK. This method may
     /// only be called by the owner of the Position. This function will fail if the circuit breaker
     /// is tripped
     function lockOwnPosition(uint256 tokenID_, uint256 lockDuration_)
@@ -244,14 +184,14 @@ abstract contract StakeNFTBase is
             "StakeNFT: Error, token doesn't exist or doesn't belong to the caller!"
         );
         require(
-            lockDuration_ <= _maxGovernanceLock,
+            lockDuration_ <= _MAX_GOVERNANCE_LOCK,
             "StakeNFT: Lock Duration is greater than the amount allowed!"
         );
         return _lockPosition(tokenID_, lockDuration_);
     }
 
     /// This function will lock withdraws on the specified Position for up to
-    /// _maxGovernanceLock. This function will fail if the circuit breaker is tripped
+    /// _MAX_GOVERNANCE_LOCK. This function will fail if the circuit breaker is tripped
     function lockWithdraw(uint256 tokenID_, uint256 lockDuration_)
         public
         withCircuitBreaker
@@ -262,7 +202,7 @@ abstract contract StakeNFTBase is
             "StakeNFT: Error, token doesn't exist or doesn't belong to the caller!"
         );
         require(
-            lockDuration_ <= _maxGovernanceLock,
+            lockDuration_ <= _MAX_GOVERNANCE_LOCK,
             "StakeNFT: Lock Duration is greater than the amount allowed!"
         );
         return _lockWithdraw(tokenID_, lockDuration_);
@@ -425,6 +365,56 @@ abstract contract StakeNFTBase is
         return payout;
     }
 
+    function circuitBreakerState() public view returns (bool) {
+        return _circuitBreaker;
+    }
+
+    /// gets the total amount of MadToken staked in contract
+    function getTotalShares() public view returns (uint256) {
+        return _shares;
+    }
+
+    /// gets the total amount of Ether staked in contract
+    function getTotalReserveEth() public view returns (uint256) {
+        return _reserveEth;
+    }
+
+    /// gets the total amount of MadToken staked in contract
+    function getTotalReserveMadToken() public view returns (uint256) {
+        return _reserveToken;
+    }
+
+    /// estimateEthCollection returns the amount of eth a tokenID may withdraw
+    function estimateEthCollection(uint256 tokenID_) public view returns (uint256 payout) {
+        require(_exists(tokenID_), "StakeNFT: Error, NFT token doesn't exist!");
+        Position memory p = _positions[tokenID_];
+        (, , , payout) = _collect(_shares, _ethState, p, p.accumulatorEth);
+        return payout;
+    }
+
+    /// estimateTokenCollection returns the amount of MadToken a tokenID may withdraw
+    function estimateTokenCollection(uint256 tokenID_) public view returns (uint256 payout) {
+        require(_exists(tokenID_), "StakeNFT: Error, NFT token doesn't exist!");
+        Position memory p = _positions[tokenID_];
+        (, , , payout) = _collect(_shares, _tokenState, p, p.accumulatorToken);
+        return payout;
+    }
+
+    /// estimateExcessToken returns the amount of MadToken that is held in the
+    /// name of this contract. The value returned is the value that would be
+    /// returned by a call to skimExcessToken.
+    function estimateExcessToken() public view returns (uint256 excess) {
+        (, excess) = _estimateExcessToken();
+        return excess;
+    }
+
+    /// estimateExcessEth returns the amount of Eth that is held in the name of
+    /// this contract. The value returned is the value that would be returned by
+    /// a call to skimExcessEth.
+    function estimateExcessEth() public view returns (uint256 excess) {
+        return _estimateExcessEth();
+    }
+
     /// gets the position struct given a tokenID. The tokenId must
     /// exist.
     function getPosition(uint256 tokenID_)
@@ -447,16 +437,17 @@ abstract contract StakeNFTBase is
         accumulatorToken = p.accumulatorToken;
     }
 
-    /// gets the current value for the Eth accumulator
-    function getEthAccumulator() external view returns (uint256 accumulator, uint256 slush) {
-        accumulator = _ethState.accumulator;
-        slush = _ethState.slush;
+    /// gets the _ACCUMULATOR_SCALE_FACTOR used to scale the ether and tokens
+    /// deposited on this contract to reduce the integer division errors.
+    function getAccumulatorScaleFactor() public pure returns (uint256) {
+        return _ACCUMULATOR_SCALE_FACTOR;
     }
 
-    /// gets the current value for the Token accumulator
-    function getTokenAccumulator() external view returns (uint256 accumulator, uint256 slush) {
-        accumulator = _tokenState.accumulator;
-        slush = _tokenState.slush;
+    function __stakeNFTBaseInit(string memory name_, string memory symbol_)
+        internal
+        onlyInitializing
+    {
+        __ERC721_init(name_, symbol_);
     }
 
     // _lockPosition prevents a position from being burned for duration_ number
@@ -563,36 +554,6 @@ abstract contract StakeNFTBase is
         return (payoutEth, payoutToken);
     }
 
-    // _estimateExcessEth returns the amount of Eth that is held in the name of
-    // this contract
-    function _estimateExcessEth() internal view returns (uint256 excess) {
-        uint256 reserve = _reserveEth;
-        uint256 balance = address(this).balance;
-        require(
-            balance >= reserve,
-            "StakeNFT: The balance of the contract is less then the tracked reserve!"
-        );
-        excess = balance - reserve;
-    }
-
-    // _estimateExcessToken returns the amount of MadToken that is held in the
-    // name of this contract
-    function _estimateExcessToken()
-        internal
-        view
-        returns (IERC20Transferable MadToken, uint256 excess)
-    {
-        uint256 reserve = _reserveToken;
-        MadToken = IERC20Transferable(_MadTokenAddress());
-        uint256 balance = MadToken.balanceOf(address(this));
-        require(
-            balance >= reserve,
-            "StakeNFT: The balance of the contract is less then the tracked reserve!"
-        );
-        excess = balance - reserve;
-        return (MadToken, excess);
-    }
-
     function _collectToken(uint256 shares_, Position memory p_)
         internal
         returns (Position memory p, uint256 payout)
@@ -613,6 +574,64 @@ abstract contract StakeNFTBase is
         (_ethState, p, acc, payout) = _collect(shares_, _ethState, p_, p_.accumulatorEth);
         p.accumulatorEth = acc;
         return (p, payout);
+    }
+
+    function _tripCB() internal {
+        require(
+            _circuitBreaker == _CIRCUIT_BREAKER_CLOSED,
+            "CircuitBreaker: The Circuit breaker is opened!"
+        );
+        _circuitBreaker = _CIRCUIT_BREAKER_OPENED;
+    }
+
+    function _resetCB() internal {
+        require(
+            _circuitBreaker == _CIRCUIT_BREAKER_OPENED,
+            "CircuitBreaker: The Circuit breaker is closed!"
+        );
+        _circuitBreaker = _CIRCUIT_BREAKER_CLOSED;
+    }
+
+    // _newTokenID increments the counter and returns the new value
+    function _increment() internal returns (uint256 count) {
+        count = _counter;
+        count += 1;
+        _counter = count;
+        return count;
+    }
+
+    // _estimateExcessEth returns the amount of Eth that is held in the name of
+    // this contract
+    function _estimateExcessEth() internal view returns (uint256 excess) {
+        uint256 reserve = _reserveEth;
+        uint256 balance = address(this).balance;
+        require(
+            balance >= reserve,
+            "StakeNFT: The balance of the contract is less then the tracked reserve!"
+        );
+        excess = balance - reserve;
+    }
+
+    // _estimateExcessToken returns the amount of MadToken that is held in the
+    // name of this contract
+    function _estimateExcessToken()
+        internal
+        view
+        returns (IERC20Transferable madToken, uint256 excess)
+    {
+        uint256 reserve = _reserveToken;
+        madToken = IERC20Transferable(_MadTokenAddress());
+        uint256 balance = madToken.balanceOf(address(this));
+        require(
+            balance >= reserve,
+            "StakeNFT: The balance of the contract is less then the tracked reserve!"
+        );
+        excess = balance - reserve;
+        return (madToken, excess);
+    }
+
+    function _getCount() internal view returns (uint256) {
+        return _counter;
     }
 
     // _collect performs calculations necessary to determine any distributions
@@ -707,38 +726,6 @@ abstract contract StakeNFTBase is
         }
         return (accumulator_, slush_);
     }
-
-    // function _isAllowedProposal(address addr) internal view returns(bool) {
-    //     return IGovernanceManager(_GovernanceAddress()).allowedProposal() == addr;
-    // }
-
-    function _tripCB() internal {
-        require(
-            _circuitBreaker == CIRCUIT_BREAKER_CLOSED,
-            "CircuitBreaker: The Circuit breaker is opened!"
-        );
-        _circuitBreaker = CIRCUIT_BREAKER_OPENED;
-    }
-
-    function _resetCB() internal {
-        require(
-            _circuitBreaker == CIRCUIT_BREAKER_OPENED,
-            "CircuitBreaker: The Circuit breaker is closed!"
-        );
-        _circuitBreaker = CIRCUIT_BREAKER_CLOSED;
-    }
-
-    // _newTokenID increments the counter and returns the new value
-    function _increment() internal returns (uint256 count) {
-        count = _counter;
-        count += 1;
-        _counter = count;
-        return count;
-    }
-
-    function _getCount() internal view returns (uint256) {
-        return _counter;
-    }
 }
 
 /// @custom:salt StakeNFT
@@ -747,6 +734,6 @@ contract StakeNFT is StakeNFTBase {
     constructor() StakeNFTBase() {}
 
     function initialize() public onlyFactory initializer {
-        __StakeNFTBase_init("MNSNFT", "MNS");
+        __stakeNFTBaseInit("MNSNFT", "MNS");
     }
 }

--- a/bridge/contracts/ValidatorNFT.sol
+++ b/bridge/contracts/ValidatorNFT.sol
@@ -10,7 +10,7 @@ contract ValidatorNFT is StakeNFTBase {
     constructor() StakeNFTBase() {}
 
     function initialize() public initializer onlyFactory {
-        __StakeNFTBase_init("MNVSNFT", "MNVS");
+        __stakeNFTBaseInit("MNVSNFT", "MNVS");
     }
 
     /// mint allows a staking position to be opened. This function

--- a/bridge/contracts/interfaces/IERC20Transferable.sol
+++ b/bridge/contracts/interfaces/IERC20Transferable.sol
@@ -10,7 +10,7 @@ interface IERC20Transferable {
 
     function transfer(address recipient, uint256 amount) external returns (bool);
 
-    function balanceOf(address account) external view returns (uint256);
-
     function approve(address spender, uint256 amount) external returns (bool);
+
+    function balanceOf(address account) external view returns (uint256);
 }

--- a/bridge/contracts/interfaces/IETHDKG.sol
+++ b/bridge/contracts/interfaces/IETHDKG.sol
@@ -10,35 +10,6 @@ interface IETHDKG {
 
     function setCustomMadnetHeight(uint256 madnetHeight) external;
 
-    function isETHDKGRunning() external view returns (bool);
-
-    function isMasterPublicKeySet() external view returns (bool);
-
-    function getNonce() external view returns (uint256);
-
-    function getPhaseStartBlock() external view returns (uint256);
-
-    function getPhaseLength() external view returns (uint256);
-
-    function getConfirmationLength() external view returns (uint256);
-
-    function getETHDKGPhase() external view returns (Phase);
-
-    function getNumParticipants() external view returns (uint256);
-
-    function getBadParticipants() external view returns (uint256);
-
-    function getMinValidators() external view returns (uint256);
-
-    function getParticipantInternalState(address participant)
-        external
-        view
-        returns (Participant memory);
-
-    function getMasterPublicKey() external view returns (uint256[4] memory);
-
-    function tryGetParticipantIndex(address participant) external view returns (bool, uint256);
-
     function initializeETHDKG() external;
 
     function register(uint256[2] memory publicKey) external;
@@ -80,4 +51,33 @@ interface IETHDKG {
         uint256[2][][] memory commitments,
         address dishonestAddress
     ) external;
+
+    function isETHDKGRunning() external view returns (bool);
+
+    function isMasterPublicKeySet() external view returns (bool);
+
+    function getNonce() external view returns (uint256);
+
+    function getPhaseStartBlock() external view returns (uint256);
+
+    function getPhaseLength() external view returns (uint256);
+
+    function getConfirmationLength() external view returns (uint256);
+
+    function getETHDKGPhase() external view returns (Phase);
+
+    function getNumParticipants() external view returns (uint256);
+
+    function getBadParticipants() external view returns (uint256);
+
+    function getMinValidators() external view returns (uint256);
+
+    function getParticipantInternalState(address participant)
+        external
+        view
+        returns (Participant memory);
+
+    function getMasterPublicKey() external view returns (uint256[4] memory);
+
+    function tryGetParticipantIndex(address participant) external view returns (bool, uint256);
 }

--- a/bridge/contracts/interfaces/INFTStake.sol
+++ b/bridge/contracts/interfaces/INFTStake.sol
@@ -2,22 +2,6 @@
 pragma solidity ^0.8.11;
 
 interface INFTStake {
-    function getAccumulatorScaleFactor() external view returns (uint256);
-
-    function getTotalShares() external view returns (uint256);
-
-    function getTotalReserveEth() external view returns (uint256);
-
-    function getTotalReserveMadToken() external view returns (uint256);
-
-    function estimateEthCollection(uint256 tokenID_) external view returns (uint256 payout);
-
-    function estimateTokenCollection(uint256 tokenID_) external view returns (uint256 payout);
-
-    function estimateExcessToken() external view returns (uint256 excess);
-
-    function estimateExcessEth() external view returns (uint256 excess);
-
     function skimExcessEth(address to_) external returns (uint256 excess);
 
     function skimExcessToken(address to_) external returns (uint256 excess);
@@ -68,6 +52,22 @@ interface INFTStake {
             uint256 accumulatorEth,
             uint256 accumulatorToken
         );
+
+    function getAccumulatorScaleFactor() external view returns (uint256);
+
+    function getTotalShares() external view returns (uint256);
+
+    function getTotalReserveEth() external view returns (uint256);
+
+    function getTotalReserveMadToken() external view returns (uint256);
+
+    function estimateEthCollection(uint256 tokenID_) external view returns (uint256 payout);
+
+    function estimateTokenCollection(uint256 tokenID_) external view returns (uint256 payout);
+
+    function estimateExcessToken() external view returns (uint256 excess);
+
+    function estimateExcessEth() external view returns (uint256 excess);
 
     function getEthAccumulator() external view returns (uint256 accumulator, uint256 slush);
 

--- a/bridge/contracts/interfaces/ISnapshots.sol
+++ b/bridge/contracts/interfaces/ISnapshots.sol
@@ -20,9 +20,13 @@ interface ISnapshots {
 
     function setSnapshotDesperationDelay(uint32 desperationDelay_) external;
 
-    function getSnapshotDesperationDelay() external view returns (uint256);
-
     function setSnapshotDesperationFactor(uint32 desperationFactor_) external;
+
+    function snapshot(bytes calldata signatureGroup_, bytes calldata bClaims_)
+        external
+        returns (bool);
+
+    function getSnapshotDesperationDelay() external view returns (uint256);
 
     function getSnapshotDesperationFactor() external view returns (uint256);
 
@@ -57,10 +61,6 @@ interface ISnapshots {
     function getSnapshot(uint256 epoch_) external view returns (Snapshot memory);
 
     function getLatestSnapshot() external view returns (Snapshot memory);
-
-    function snapshot(bytes calldata signatureGroup_, bytes calldata bClaims_)
-        external
-        returns (bool);
 
     function mayValidatorSnapshot(
         uint256 numValidators,

--- a/bridge/contracts/interfaces/IValidatorPool.sol
+++ b/bridge/contracts/interfaces/IValidatorPool.sol
@@ -18,6 +18,31 @@ interface IValidatorPool {
 
     function setLocation(string calldata ip) external;
 
+    function scheduleMaintenance() external;
+
+    function initializeETHDKG() external;
+
+    function completeETHDKG() external;
+
+    function pauseConsensus() external;
+
+    function pauseConsensusOnArbitraryHeight(uint256 madnetHeight) external;
+
+    function registerValidators(address[] calldata validators, uint256[] calldata stakerTokenIDs)
+        external;
+
+    function unregisterValidators(address[] calldata validators) external;
+
+    function unregisterAllValidators() external;
+
+    function collectProfits() external returns (uint256 payoutEth, uint256 payoutToken);
+
+    function claimExitingNFTPosition() external returns (uint256);
+
+    function majorSlash(address dishonestValidator_, address disputer_) external;
+
+    function minorSlash(address dishonestValidator_, address disputer_) external;
+
     function getValidatorsCount() external view returns (uint256);
 
     function getValidatorsAddresses() external view returns (address[] memory);
@@ -52,31 +77,6 @@ interface IValidatorPool {
     function isAccusable(address participant) external view returns (bool);
 
     function isMaintenanceScheduled() external view returns (bool);
-
-    function scheduleMaintenance() external;
-
-    function initializeETHDKG() external;
-
-    function completeETHDKG() external;
-
-    function pauseConsensus() external;
-
-    function pauseConsensusOnArbitraryHeight(uint256 madnetHeight) external;
-
-    function registerValidators(address[] calldata validators, uint256[] calldata stakerTokenIDs)
-        external;
-
-    function unregisterValidators(address[] calldata validators) external;
-
-    function unregisterAllValidators() external;
-
-    function collectProfits() external returns (uint256 payoutEth, uint256 payoutToken);
-
-    function claimExitingNFTPosition() external returns (uint256);
-
-    function majorSlash(address dishonestValidator_, address disputer_) external;
-
-    function minorSlash(address dishonestValidator_, address disputer_) external;
 
     function isConsensusRunning() external view returns (bool);
 }

--- a/bridge/contracts/libraries/ethdkg/ETHDKGPhases.sol
+++ b/bridge/contracts/libraries/ethdkg/ETHDKGPhases.sol
@@ -12,10 +12,6 @@ import "contracts/utils/ETHDKGUtils.sol";
 contract ETHDKGPhases is ETHDKGStorage, IETHDKGEvents, ETHDKGUtils {
     constructor() ETHDKGStorage() {}
 
-    function getMyAddress() public view returns (address) {
-        return address(this);
-    }
-
     function register(uint256[2] memory publicKey) external {
         require(
             _ethdkgPhase == Phase.RegistrationOpen &&
@@ -342,6 +338,10 @@ contract ETHDKGPhases is ETHDKGStorage, IETHDKGEvents, ETHDKGUtils {
             _masterPublicKey[2],
             _masterPublicKey[3]
         );
+    }
+
+    function getMyAddress() public view returns (address) {
+        return address(this);
     }
 
     function _setPhase(Phase phase_) internal {

--- a/bridge/contracts/libraries/ethdkg/ETHDKGStorage.sol
+++ b/bridge/contracts/libraries/ethdkg/ETHDKGStorage.sol
@@ -38,7 +38,7 @@ abstract contract ETHDKGStorage is
     // ISnapshots internal immutable _snapshots;
     // IValidatorPool internal immutable _validatorPool;
     //address internal immutable _factory;
-    uint256 internal constant MIN_VALIDATOR = 4;
+    uint256 internal constant _MIN_VALIDATORS = 4;
 
     uint64 internal _nonce;
     uint64 internal _phaseStartBlock;

--- a/bridge/contracts/libraries/factory/MadnetFactoryBase.sol
+++ b/bridge/contracts/libraries/factory/MadnetFactoryBase.sol
@@ -7,28 +7,28 @@ import "contracts/interfaces/IProxy.sol";
 
 abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
     /**
-    @dev owner role for priveledged access to functions
+    @dev owner role for privileged access to functions
     */
-    address private owner_;
+    address private _owner;
 
     /**
-    @dev delegator role for priveledged access to delegateCallAny
+    @dev delegator role for privileged access to delegateCallAny
     */
-    address private delegator_;
+    address private _delegator;
 
     /**
     @dev array to store list of contract salts
     */
-    bytes32[] private contracts_;
+    bytes32[] private _contracts;
 
     /**
     @dev slot for storing implementation address
     */
-    address private implementation_;
+    address private _implementation;
 
-    address private immutable proxyTemplate_;
+    address private immutable _proxyTemplate;
 
-    bytes8 private constant universalDeployCode_ = 0x38585839386009f3;
+    bytes8 private constant _UNIVERSAL_DEPLOY_CODE = 0x38585839386009f3;
 
     /**
      *@dev events that notify of contract deployment
@@ -41,31 +41,32 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
 
     // modifier restricts caller to owner or self via multicall
     modifier onlyOwner() {
-        requireAuth(msg.sender == address(this) || msg.sender == owner());
+        _requireAuth(msg.sender == address(this) || msg.sender == owner());
         _;
     }
 
     // modifier restricts caller to owner or self via multicall
     modifier onlyOwnerOrDelegator() {
-        requireAuth(
+        _requireAuth(
             msg.sender == address(this) || msg.sender == owner() || msg.sender == delegator()
         );
         _;
     }
 
     /**
-     * @dev The constructor encodes the proxy deploy byte code with the universal deploycode at
-     * the head and the factory address at the tail, and deploys the proxy byte code using create
-     * The result of this deployment will be a contract with the proxy contract deployment bytecode
-     * with its constructor at the head, runtime code in the body and constructor args at the tail.
-     * the constructor then sets proxyTemplate_ state var to the deployed proxy template address
-     * the deploy account will be set as the first owner of the factory.
-     * @param selfAddr_ is the factory contracts address (address of itself)
+     * @dev The constructor encodes the proxy deploy byte code with the _UNIVERSAL_DEPLOY_CODE at the
+     * head and the factory address at the tail, and deploys the proxy byte code using create OpCode.
+     * The result of this deployment will be a contract with the proxy contract deployment bytecode with
+     * its constructor at the head, runtime code in the body and constructor args at the tail. The
+     * constructor then sets proxyTemplate_ state var to the deployed proxy template address the deploy
+     * account will be set as the first owner of the factory.
+     * @param selfAddr_ is the factory contracts
+     * address (address of itself)
      */
     constructor(address selfAddr_) {
         bytes memory proxyDeployCode = abi.encodePacked(
             //8 byte code copy constructor code
-            universalDeployCode_,
+            _UNIVERSAL_DEPLOY_CODE,
             type(Proxy).creationCode,
             bytes32(uint256(uint160(selfAddr_)))
         );
@@ -82,68 +83,90 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
             }
         }
         //State var that stores the proxyTemplate address
-        proxyTemplate_ = addr;
-        //State var that stores the owner_ address
-        owner_ = msg.sender;
+        _proxyTemplate = addr;
+        //State var that stores the _owner address
+        _owner = msg.sender;
+    }
+
+    // solhint-disable payable-fallback
+    /**
+     * @dev fallback function returns the address of the most recent deployment of a template
+     */
+    fallback() external {
+        assembly {
+            mstore(returndatasize(), sload(_implementation.slot))
+            return(returndatasize(), 0x20)
+        }
     }
 
     /**
-     * @dev lookup allows anyone interacting with the contract to
-     * get the address of contract specified by its _name
-     * @param _name: Custom NatSpec tag @custom:salt at the top of the contract
-     * solidity file
+     * @dev Sets a new implementation address
+     * @param newImplementationAddress_: address of the contract with the new implementation
      */
-    function lookup(string memory _name) public view returns (address addr) {
+    function setImplementation(address newImplementationAddress_) public onlyOwnerOrDelegator {
+        _implementation = newImplementationAddress_;
+    }
+
+    /**
+     * @dev Sets the new owner
+     * @param newOwner_: address of the new owner
+     */
+    function setOwner(address newOwner_) public onlyOwner {
+        _owner = newOwner_;
+    }
+
+    /**
+     * @dev Sets the new delegator
+     * @param newDelegator_: address of the new delegator
+     */
+    function setDelegator(address newDelegator_) public onlyOwner {
+        _delegator = newDelegator_;
+    }
+
+    /**
+     * @dev lookup allows anyone interacting with the contract to get the address of contract specified
+     * by its name_
+     * @param name_: Custom NatSpec tag @custom:salt at the top of the contract solidity file
+     */
+    function lookup(string memory name_) public view returns (address addr) {
         bytes32 salt;
         assembly {
-            salt := mload(add(_name, 32))
+            salt := mload(add(name_, 32))
         }
         addr = getMetamorphicContractAddress(salt, address(this));
     }
 
+    /**
+     * @dev getImplementation is public getter function for the _owner account address
+     */
     function getImplementation() public view returns (address) {
-        return implementation_;
-    }
-
-    function setImplementation(address _v) public onlyOwnerOrDelegator {
-        implementation_ = _v;
-    }
-
-    function setOwner(address _v) public onlyOwner {
-        owner_ = _v;
-    }
-
-    function setDelegator(address _v) public onlyOwner {
-        delegator_ = _v;
-    }
-
-    function implementation() public view returns (address _v) {
-        _v = implementation_;
+        return _implementation;
     }
 
     /**
-     * @dev owner is public getter function for the owner_ account address
-     * @return _v address of the owner account
+     * @dev owner is public getter function for the _owner account address
+     * @return owner_ address of the owner account
      */
-    function owner() public view returns (address _v) {
-        _v = owner_;
+    function owner() public view returns (address owner_) {
+        owner_ = _owner;
     }
 
     /**
-     * @dev delegator is public getter function for the delegator_ account address
-     * @return _v address of the delegator account
+     * @dev delegator is public getter function for the _delegator account address
+     * @return delegator_ address of the delegator account
      */
-    function delegator() public view returns (address _v) {
-        _v = delegator_;
+    function delegator() public view returns (address delegator_) {
+        delegator_ = _delegator;
     }
 
     /**
-     * @dev delegator is public getter function for the delegator_ account address
-     * @return _contracts the array of salts associated with all the contracts
+     * @dev contracts is public getter that gets the array of salts associated with all the contracts
      * deployed with this factory
+     * @return contracts_ the array of salts associated with all the contracts deployed with this
+     * factory
      */
-    function contracts() public view returns (bytes32[] memory _contracts) {
-        _contracts = contracts_;
+    function contracts() public view returns (bytes32[] memory contracts_) {
+        contracts_ = _contracts;
     }
 
     /**
@@ -151,47 +174,86 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
      * deployed with this factory
      * @return the length of the contract array
      */
-    function getNumContracts() external view returns (uint256) {
-        return contracts_.length;
+    function getNumContracts() public view returns (uint256) {
+        return _contracts.length;
     }
 
     /**
-     * @dev deployCreate allows the owner to deploy raw contracts through the factory
-     * @param _deployCode bytecode to deploy using create
+     * @dev _callAny allows EOA to call function impersonating the factory address
+     * @param target_: the address of the contract to be called
+     * @param value_: value in WEIs to send together the call
+     * @param cdata_: Hex encoded data with function signature + arguments of the target function to be called
      */
-    function deployCreateInternal(bytes calldata _deployCode)
-        internal
-        returns (address contractAddr)
-    {
+    function _callAny(
+        address target_,
+        uint256 value_,
+        bytes memory cdata_
+    ) internal {
+        assembly {
+            let size := mload(cdata_)
+            let ptr := add(0x20, cdata_)
+            if iszero(call(gas(), target_, value_, ptr, size, 0x00, 0x00)) {
+                returndatacopy(0x00, 0x00, returndatasize())
+                revert(0x00, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @dev _delegateCallAny allows EOA to call a function in a contract without impersonating the factory
+     * @param target_: the address of the contract to be called
+     * @param cdata_: Hex encoded data with function signature + arguments of the target function to be called
+     */
+    function _delegateCallAny(address target_, bytes memory cdata_) internal {
+        assembly {
+            let size := mload(cdata_)
+            let ptr := add(0x20, cdata_)
+            if iszero(delegatecall(gas(), target_, ptr, size, 0x00, 0x00)) {
+                returndatacopy(0x00, 0x00, returndatasize())
+                revert(0x00, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @dev _deployCreate allows the owner to deploy raw contracts through the factory using
+     * non-deterministic address generation (create OpCode)
+     * @param deployCode_ Hex encoded data with the deployment code of the contract to be deployed +
+     * constructors' args (if any)
+     * @return contractAddr the deployed contract address
+     */
+    function _deployCreate(bytes calldata deployCode_) internal returns (address contractAddr) {
         assembly {
             //get the next free pointer
             let basePtr := mload(0x40)
             let ptr := basePtr
 
             //copies the initialization code of the implementation contract
-            calldatacopy(ptr, _deployCode.offset, _deployCode.length)
+            calldatacopy(ptr, deployCode_.offset, deployCode_.length)
 
             //Move the ptr to the end of the code in memory
-            ptr := add(ptr, _deployCode.length)
+            ptr := add(ptr, deployCode_.length)
 
             contractAddr := create(0, basePtr, sub(ptr, basePtr))
         }
-        codeSizeZeroRevert((extCodeSize(contractAddr) != 0));
+        _codeSizeZeroRevert((_extCodeSize(contractAddr) != 0));
         emit DeployedRaw(contractAddr);
         return contractAddr;
     }
 
     /**
-     * @dev deployCreate2 allows the owner to deploy contracts with deterministic address
-     * through the factory
-     * @param _value endowment value for created contract
-     * @param _salt salt for create2 deployment, used to distinguish contracts deployed from this factory
-     * @param _deployCode bytecode to deploy using create2
+     * @dev _deployCreate2 allows the owner to deploy contracts with deterministic address through the
+     * factory
+     * @param value_ endowment value in WEIS for the created contract
+     * @param salt_ salt used to determine the final determinist address for the deployed contract
+     * @param deployCode_ Hex encoded data with the deployment code of the contract to be deployed +
+     * constructors' args (if any)
+     * @return contractAddr the deployed contract address
      */
-    function deployCreate2Internal(
-        uint256 _value,
-        bytes32 _salt,
-        bytes calldata _deployCode
+    function _deployCreate2(
+        uint256 value_,
+        bytes32 salt_,
+        bytes calldata deployCode_
     ) internal returns (address contractAddr) {
         assembly {
             //get the next free pointer
@@ -199,92 +261,63 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
             let ptr := basePtr
 
             //copies the initialization code of the implementation contract
-            calldatacopy(ptr, _deployCode.offset, _deployCode.length)
+            calldatacopy(ptr, deployCode_.offset, deployCode_.length)
 
             //Move the ptr to the end of the code in memory
-            ptr := add(ptr, _deployCode.length)
+            ptr := add(ptr, deployCode_.length)
 
-            contractAddr := create2(_value, basePtr, sub(ptr, basePtr), _salt)
+            contractAddr := create2(value_, basePtr, sub(ptr, basePtr), salt_)
         }
-        codeSizeZeroRevert(uint160(contractAddr) != 0);
-        //record the contract salt to the contracts_ array for lookup
-        contracts_.push(_salt);
+        _codeSizeZeroRevert(uint160(contractAddr) != 0);
+        //record the contract salt to the _contracts array for lookup
+        _contracts.push(salt_);
         emit DeployedRaw(contractAddr);
         return contractAddr;
     }
 
-    /*
-     * @dev destroy calls the template contract with arbitrary call data which will cause it to self destruct
-     * param _contractAddr the address of the contract to self destruct
-     */
-    function initializeContractInternal(address _contract, bytes calldata _initCallData) internal {
-        assembly {
-            if iszero(iszero(_initCallData.length)) {
-                let ptr := mload(0x40)
-                mstore(0x40, add(_initCallData.length, ptr))
-                calldatacopy(ptr, _initCallData.offset, _initCallData.length)
-                if iszero(call(gas(), _contract, 0, ptr, _initCallData.length, 0x00, 0x00)) {
-                    ptr := mload(0x40)
-                    mstore(0x40, add(returndatasize(), ptr))
-                    returndatacopy(ptr, 0x00, returndatasize())
-                    revert(ptr, returndatasize())
-                }
-            }
-        }
-    }
-
     /**
-     * @dev deployTemplate deploys a template contract with the universal code copy constructor that deploys
-     * the deploycode as the contracts runtime code.
-     * @param _deployCode the deploycode with the constructor args appended if any
-     * @return contractAddr the address of the deployed template contract
+     * @dev _deployProxy deploys a proxy contract with upgradable logic. See Proxy.sol contract.
+     * @param salt_ salt used to determine the final determinist address for the deployed contract
      */
-    function deployTemplateInternal(bytes calldata _deployCode)
-        internal
-        returns (address contractAddr)
-    {
+    function _deployProxy(bytes32 salt_) internal returns (address contractAddr) {
+        address proxyTemplate = _proxyTemplate;
         assembly {
-            //get the next free pointer
-            let basePtr := mload(0x40)
-            mstore(0x40, add(basePtr, add(_deployCode.length, 0x28)))
-            let ptr := basePtr
-            //codesize, pc,  pc, codecopy, codesize, push1 09, return push2 <codesize> 56 5b
-            mstore(ptr, hex"38585839386009f3")
-            //0x38585839386009f3
-            ptr := add(ptr, 0x08)
-            //copy the initialization code of the implementation contract
-            calldatacopy(ptr, _deployCode.offset, _deployCode.length)
-            // Move the ptr to the end of the code in memory
-            ptr := add(ptr, _deployCode.length)
-            // put address on constructor
-            mstore(ptr, address())
-            ptr := add(ptr, 0x20)
-            contractAddr := create(0, basePtr, sub(ptr, basePtr))
+            // store proxy template address as implementation,
+            sstore(_implementation.slot, proxyTemplate)
+            let ptr := mload(0x40)
+            mstore(0x40, add(ptr, 0x20))
+            // put metamorphic code as initCode
+            // push1 20
+            mstore(ptr, shl(72, 0x6020363636335afa1536363636515af43d36363e3d36f3))
+            contractAddr := create2(0, ptr, 0x17, salt_)
         }
-        codeSizeZeroRevert((extCodeSize(contractAddr) != 0));
-        emit DeployedTemplate(contractAddr);
-        implementation_ = contractAddr;
+        _codeSizeZeroRevert((_extCodeSize(contractAddr) != 0));
+        // record the contract salt to the contracts array
+        _contracts.push(salt_);
+        emit DeployedProxy(contractAddr);
         return contractAddr;
     }
 
     /**
-     * @dev deployStatic deploys a template contract with the universal code copy constructor that deploys
-     * the deploycode as the contracts runtime code.
-     * @param _salt sda
+     * @dev _deployStatic finishes the deployment started with the deployTemplate of a contract with
+     * determinist address. This function call any initialize() function in the deployed contract
+     * in case the arguments are provided. Should be called after deployTemplate.
+     * @param salt_ salt used to determine the final determinist address for the deployed contract
+     * @param initCallData_ Hex encoded initialization function signature + parameters to initialize the deployed contract
      * @return contractAddr the address of the deployed template contract
      */
-    function deployStaticInternal(bytes32 _salt, bytes calldata _initCallData)
+    function _deployStatic(bytes32 salt_, bytes calldata initCallData_)
         internal
         returns (address contractAddr)
     {
         assembly {
             // store proxy template address as implementation,
-            //sstore(implementation_.slot, _impl)
+            //sstore(_implementation.slot, _impl)
             let ptr := mload(0x40)
             mstore(0x40, add(ptr, 0x20))
             // put metamorphic code as initcode
             mstore(ptr, shl(72, 0x6020363636335afa1536363636515af43d36363e3d36f3))
-            contractAddr := create2(0, ptr, 0x17, _salt)
+            contractAddr := create2(0, ptr, 0x17, salt_)
             //if the returndatasize is not 0 revert with the error message
             if iszero(iszero(returndatasize())) {
                 returndatacopy(0x00, 0x00, returndatasize())
@@ -296,62 +329,113 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
                 revert(0, 0x20)
             }
         }
-        if (_initCallData.length > 0) {
-            initializeContractInternal(contractAddr, _initCallData);
+        if (initCallData_.length > 0) {
+            _initializeContract(contractAddr, initCallData_);
         }
-        codeSizeZeroRevert((extCodeSize(contractAddr) != 0));
-        contracts_.push(_salt);
+        _codeSizeZeroRevert((_extCodeSize(contractAddr) != 0));
+        _contracts.push(salt_);
         emit DeployedStatic(contractAddr);
         return contractAddr;
     }
 
     /**
-     *
+     * @dev _deployTemplate deploys a template contract with the universal code copy constructor that
+     * deploys the contract+constructorArgs defined in the deployCode_ as the contracts runtime code.
+     * @param deployCode_ Hex encoded data with the deploymentCode + (constructor args appended if any)
+     * @return contractAddr the address of the deployed template contract
      */
-    function deployProxyInternal(bytes32 _salt) internal returns (address contractAddr) {
-        address proxyTemplate = proxyTemplate_;
+    function _deployTemplate(bytes calldata deployCode_) internal returns (address contractAddr) {
         assembly {
-            // store proxy template address as implementation,
-            sstore(implementation_.slot, proxyTemplate)
-            let ptr := mload(0x40)
-            mstore(0x40, add(ptr, 0x20))
-            // put metamorphic code as initcode
-            //push1 20
-            mstore(ptr, shl(72, 0x6020363636335afa1536363636515af43d36363e3d36f3))
-            contractAddr := create2(0, ptr, 0x17, _salt)
+            //get the next free pointer
+            let basePtr := mload(0x40)
+            mstore(0x40, add(basePtr, add(deployCode_.length, 0x28)))
+            let ptr := basePtr
+            //codesize, pc,  pc, codecopy, codesize, push1 09, return push2 <codesize> 56 5b
+            mstore(ptr, hex"38585839386009f3")
+            //0x38585839386009f3
+            ptr := add(ptr, 0x08)
+            //copy the initialization code of the implementation contract
+            calldatacopy(ptr, deployCode_.offset, deployCode_.length)
+            // Move the ptr to the end of the code in memory
+            ptr := add(ptr, deployCode_.length)
+            // put address on constructor
+            mstore(ptr, address())
+            ptr := add(ptr, 0x20)
+            contractAddr := create(0, basePtr, sub(ptr, basePtr))
         }
-        codeSizeZeroRevert((extCodeSize(contractAddr) != 0));
-        //record the contract salt to the contracts array
-        contracts_.push(_salt);
-        emit DeployedProxy(contractAddr);
+        _codeSizeZeroRevert((_extCodeSize(contractAddr) != 0));
+        emit DeployedTemplate(contractAddr);
+        _implementation = contractAddr;
         return contractAddr;
     }
 
-    function upgradeProxyInternal(
-        bytes32 _salt,
-        address _newImpl,
-        bytes calldata _initCallData
-    ) internal {
-        address proxy = DeterministicAddress.getMetamorphicContractAddress(_salt, address(this));
-        __upgrade(proxy, _newImpl);
-        assert(IProxy(proxy).getImplementationAddress() == _newImpl);
-        initializeContractInternal(proxy, _initCallData);
+    /**
+     * @dev _initializeContract allows the owner/delegator to initialize contracts deployed via factory
+     * @param contract_ address of the contract that will be initialized
+     * @param initCallData_ Hex encoded initialization function signature + parameters to initialize the
+     * deployed contract
+     */
+    function _initializeContract(address contract_, bytes calldata initCallData_) internal {
+        assembly {
+            if iszero(iszero(initCallData_.length)) {
+                let ptr := mload(0x40)
+                mstore(0x40, add(initCallData_.length, ptr))
+                calldatacopy(ptr, initCallData_.offset, initCallData_.length)
+                if iszero(call(gas(), contract_, 0, ptr, initCallData_.length, 0x00, 0x00)) {
+                    ptr := mload(0x40)
+                    mstore(0x40, add(returndatasize(), ptr))
+                    returndatacopy(ptr, 0x00, returndatasize())
+                    revert(ptr, returndatasize())
+                }
+            }
+        }
     }
 
     /**
-     * @dev multiCallInternal allows EOA to make multiple function calls within a single transaction **in this contract**, and only returns the result of the last call
-     * @param _cdata: array of function calls
-     * returns the result of the last call
+     * @dev _multiCall allows EOA to make multiple function calls within a single transaction
+     * impersonating the factory
+     * @param cdata_: array of hex encoded data with the function calls (function signature + arguments)
      */
-    function multiCallInternal(bytes[] calldata _cdata) internal {
-        for (uint256 i = 0; i < _cdata.length; i++) {
-            bytes memory cdata = _cdata[i];
-            callAnyInternal(address(this), 0, cdata);
+    function _multiCall(bytes[] calldata cdata_) internal {
+        for (uint256 i = 0; i < cdata_.length; i++) {
+            bytes memory cdata = cdata_[i];
+            _callAny(address(this), 0, cdata);
         }
-        returnAvailableData();
+        _returnAvailableData();
     }
 
-    function returnAvailableData() internal pure {
+    /**
+     * @dev _upgradeProxy updates the implementation/logic address of an already deployed proxy contract.
+     * @param salt_ salt used to determine the final determinist address for the deployed proxy contract
+     * @param newImpl_ address of the new contract that contains the new implementation logic
+     * @param initCallData_ Hex encoded initialization function signature + parameters to initialize the
+     * new implementation contract
+     */
+    function _upgradeProxy(
+        bytes32 salt_,
+        address newImpl_,
+        bytes calldata initCallData_
+    ) internal {
+        address proxy = DeterministicAddress.getMetamorphicContractAddress(salt_, address(this));
+        __upgrade(proxy, newImpl_);
+        assert(IProxy(proxy).getImplementationAddress() == newImpl_);
+        _initializeContract(proxy, initCallData_);
+    }
+
+    /**
+     * @dev Aux function to return the external code size
+     */
+    function _extCodeSize(address target_) internal view returns (uint256 size) {
+        assembly {
+            size := extcodesize(target_)
+        }
+        return size;
+    }
+
+    /**
+     * @dev Aux function to get the return data size
+     */
+    function _returnAvailableData() internal pure {
         assembly {
             returndatacopy(0x00, 0x00, returndatasize())
             return(0x00, returndatasize())
@@ -359,76 +443,18 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
     }
 
     /**
-     * @dev delegateCallAnyInternal allows the logic of this contract to be updated
-     * in the event that our update/deploy mechanism is invalidated
-     * this function poses a risk, but does not grant any additional
-     * capability beyond that which is present due to other features
-     * present at this time
-     * @param _target: the address of the contract to call
-     * @param _cdata: the call data for the delegate call
+     * @dev _requireAuth reverts if false and returns unauthorized error message
+     * @param isOk_ boolean false to cause revert
      */
-    function delegateCallAnyInternal(address _target, bytes memory _cdata) internal {
-        assembly {
-            let size := mload(_cdata)
-            let ptr := add(0x20, _cdata)
-            if iszero(delegatecall(gas(), _target, ptr, size, 0x00, 0x00)) {
-                returndatacopy(0x00, 0x00, returndatasize())
-                revert(0x00, returndatasize())
-            }
-        }
+    function _requireAuth(bool isOk_) internal pure {
+        require(isOk_, "unauthorized");
     }
 
     /**
-     * @dev callAnyInternal internal functions that allows the factory contract to make arbitray calls to other contracts
-     * @param _target: the address of the contract to call
-     * @param _value: value to send with the call
-     * @param _cdata: the call data for the delegate call
+     * @dev _codeSizeZeroRevert reverts if false and returns csize0 error message
+     * @param isOk_ boolean false to cause revert
      */
-    function callAnyInternal(
-        address _target,
-        uint256 _value,
-        bytes memory _cdata
-    ) internal {
-        assembly {
-            let size := mload(_cdata)
-            let ptr := add(0x20, _cdata)
-            if iszero(call(gas(), _target, _value, ptr, size, 0x00, 0x00)) {
-                returndatacopy(0x00, 0x00, returndatasize())
-                revert(0x00, returndatasize())
-            }
-        }
-    }
-
-    /**
-     * @dev requireAuth reverts if false and returns csize0 error message
-     * @param _ok boolean false to cause revert
-     */
-    function requireAuth(bool _ok) internal pure {
-        require(_ok, "unauthorized");
-    }
-
-    /**
-     * @dev codeSizeZeroRevert reverts if false and returns csize0 error message
-     * @param _ok boolean false to cause revert
-     */
-    function codeSizeZeroRevert(bool _ok) internal pure {
-        require(_ok, "csize0");
-    }
-
-    function extCodeSize(address target) internal view returns (uint256 size) {
-        assembly {
-            size := extcodesize(target)
-        }
-        return size;
-    }
-
-    /**
-     * @dev fallback function returns the address of the most recent deployment of a template
-     */
-    fallback() external {
-        assembly {
-            mstore(returndatasize(), sload(implementation_.slot))
-            return(returndatasize(), 0x20)
-        }
+    function _codeSizeZeroRevert(bool isOk_) internal pure {
+        require(isOk_, "csize0");
     }
 }

--- a/bridge/contracts/libraries/governance/GovernanceMaxLock.sol
+++ b/bridge/contracts/libraries/governance/GovernanceMaxLock.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 abstract contract GovernanceMaxLock {
-    // _maxGovernanceLock describes the maximum interval
+    // _MAX_GOVERNANCE_LOCK describes the maximum interval
     // a position may remained locked due to a
     // governance action
     // this value is approx 30 days worth of blocks
     // prevents double spend of voting weight
-    uint256 constant _maxGovernanceLock = 172800;
+    uint256 internal constant _MAX_GOVERNANCE_LOCK = 172800;
 }

--- a/bridge/contracts/libraries/math/CryptoLibrary.sol
+++ b/bridge/contracts/libraries/math/CryptoLibrary.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT-open-group
 pragma solidity ^0.8.11;
 
+/* solhint-disable */
 /*
     Author: Philipp Schindler
     Source code and documentation available on Github: https://github.com/PhilippSchindler/ethdkg
@@ -818,3 +819,4 @@ library CryptoLibrary {
         return tmp2;
     }
 }
+/* solhint-enable */

--- a/bridge/contracts/libraries/parsers/BClaimsParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/BClaimsParserLibrary.sol
@@ -5,13 +5,6 @@ import "./BaseParserLibrary.sol";
 
 /// @title Library to parse the BClaims structure from a blob of capnproto data
 library BClaimsParserLibrary {
-    /** @dev size in bytes of a BCLAIMS cap'npro structure without the cap'n
-      proto header bytes*/
-    uint256 internal constant BCLAIMS_SIZE = 176;
-    /** @dev Number of bytes of a capnproto header, the data starts after the
-      header */
-    uint256 internal constant CAPNPROTO_HEADER_SIZE = 8;
-
     struct BClaims {
         uint32 chainId;
         uint32 height;
@@ -21,6 +14,13 @@ library BClaimsParserLibrary {
         bytes32 stateRoot;
         bytes32 headerRoot;
     }
+
+    /** @dev size in bytes of a BCLAIMS cap'npro structure without the cap'n
+      proto header bytes*/
+    uint256 internal constant _BCLAIMS_SIZE = 176;
+    /** @dev Number of bytes of a capnproto header, the data starts after the
+      header */
+    uint256 internal constant _CAPNPROTO_HEADER_SIZE = 8;
 
     /**
     @notice This function computes the offset adjustment in the pointer section
@@ -67,7 +67,7 @@ library BClaimsParserLibrary {
     /// @return bClaims the BClaims struct
     /// @dev Execution cost: 2484 gas
     function extractBClaims(bytes memory src) internal pure returns (BClaims memory bClaims) {
-        return extractInnerBClaims(src, CAPNPROTO_HEADER_SIZE, getPointerOffsetAdjustment(src, 4));
+        return extractInnerBClaims(src, _CAPNPROTO_HEADER_SIZE, getPointerOffsetAdjustment(src, 4));
     }
 
     /**
@@ -87,11 +87,11 @@ library BClaimsParserLibrary {
         uint16 pointerOffsetAdjustment
     ) internal pure returns (BClaims memory bClaims) {
         require(
-            dataOffset + BCLAIMS_SIZE - pointerOffsetAdjustment > dataOffset,
+            dataOffset + _BCLAIMS_SIZE - pointerOffsetAdjustment > dataOffset,
             "BClaimsParserLibrary: Invalid parsing. Overflow on the dataOffset parameter"
         );
         require(
-            src.length >= dataOffset + BCLAIMS_SIZE - pointerOffsetAdjustment,
+            src.length >= dataOffset + _BCLAIMS_SIZE - pointerOffsetAdjustment,
             "BClaimsParserLibrary: Invalid parsing. Not enough bytes to extract BClaims"
         );
 

--- a/bridge/contracts/libraries/parsers/BaseParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/BaseParserLibrary.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.11;
 
 library BaseParserLibrary {
     // Size of a word, in bytes.
-    uint256 internal constant WORD_SIZE = 32;
+    uint256 internal constant _WORD_SIZE = 32;
     // Size of the header of a 'bytes' array.
-    uint256 internal constant BYTES_HEADER_SIZE = 32;
+    uint256 internal constant _BYTES_HEADER_SIZE = 32;
 
     /// @notice Extracts a uint32 from a little endian bytes array.
     /// @param src the binary data
@@ -46,7 +46,7 @@ library BaseParserLibrary {
         );
         require(
             src.length >= offset + 2,
-            "BaseParserLibrary: Error extracting uin16! Trying to read an offset out of boundaries in the src binary!"
+            "BaseParserLibrary: UINT16 ERROR! Trying to read an offset out of boundaries!"
         );
 
         assembly {
@@ -67,11 +67,11 @@ library BaseParserLibrary {
     {
         require(
             offset + 2 > offset,
-            "BaseParserLibrary: Error extracting uin16! An overflow happened with the offset parameter!"
+            "BaseParserLibrary: UINT16 ERROR! An overflow happened with the offset parameter!"
         );
         require(
             src.length >= offset + 2,
-            "BaseParserLibrary: Error extracting uin16! Trying to read an offset out of boundaries in the src binary!"
+            "BaseParserLibrary: UINT16 ERROR! Trying to read an offset out of boundaries!"
         );
 
         assembly {
@@ -85,13 +85,10 @@ library BaseParserLibrary {
     /// @return a bool
     /// @dev ~204 gas
     function extractBool(bytes memory src, uint256 offset) internal pure returns (bool) {
-        require(
-            offset + 1 > offset,
-            "BaseParserLibrary: Error extracting bool! An overflow happened with the offset parameter!"
-        );
+        require(offset + 1 > offset, "BaseParserLibrary: BOOL ERROR: OVERFLOW!");
         require(
             src.length >= offset + 1,
-            "BaseParserLibrary: Error extracting bool! Trying to read an offset out of boundaries in the src binary!"
+            "BaseParserLibrary: BOOL ERROR: OFFSET OUT OF BOUNDARIES!"
         );
         uint256 val;
         assembly {
@@ -258,19 +255,19 @@ library BaseParserLibrary {
         uint256 len
     ) internal pure {
         // Copy word-length chunks while possible
-        for (; len >= WORD_SIZE; len -= WORD_SIZE) {
+        for (; len >= _WORD_SIZE; len -= _WORD_SIZE) {
             assembly {
                 mstore(dest, mload(src))
             }
-            dest += WORD_SIZE;
-            src += WORD_SIZE;
+            dest += _WORD_SIZE;
+            src += _WORD_SIZE;
         }
         // Returning earlier if there's no leftover bytes to copy
         if (len == 0) {
             return;
         }
         // Copy remaining bytes
-        uint256 mask = 256**(WORD_SIZE - len) - 1;
+        uint256 mask = 256**(_WORD_SIZE - len) - 1;
         assembly {
             let srcpart := and(mload(src), not(mask))
             let destpart := and(mload(dest), mask)
@@ -283,7 +280,7 @@ library BaseParserLibrary {
     /// @return addr the pointer to the `bts` bytes array
     function dataPtr(bytes memory bts) internal pure returns (uint256 addr) {
         assembly {
-            addr := add(bts, BYTES_HEADER_SIZE)
+            addr := add(bts, _BYTES_HEADER_SIZE)
         }
     }
 
@@ -310,7 +307,7 @@ library BaseParserLibrary {
         uint256 start;
 
         assembly {
-            start := add(add(src, offset), BYTES_HEADER_SIZE)
+            start := add(add(src, offset), _BYTES_HEADER_SIZE)
         }
 
         copy(start, dataPtr(out), howManyBytes);
@@ -328,7 +325,7 @@ library BaseParserLibrary {
         );
         require(src.length >= (offset + 32), "BaseParserLibrary: not enough bytes to extract");
         assembly {
-            out := mload(add(add(src, BYTES_HEADER_SIZE), offset))
+            out := mload(add(add(src, _BYTES_HEADER_SIZE), offset))
         }
     }
 }

--- a/bridge/contracts/libraries/parsers/MerkleProofParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/MerkleProofParserLibrary.sol
@@ -5,10 +5,6 @@ import "./BaseParserLibrary.sol";
 
 /// @title Library to parse the MerkleProof structure from a blob of binary data
 library MerkleProofParserLibrary {
-    /** @dev minimum size in bytes of a MerkleProof binary structure
-      (without proofs and bitmap) */
-    uint256 internal constant MERKLE_PROOF_SIZE = 103;
-
     struct MerkleProof {
         bool included;
         uint16 keyHeight;
@@ -18,6 +14,9 @@ library MerkleProofParserLibrary {
         bytes bitmap;
         bytes auditPath;
     }
+    /** @dev minimum size in bytes of a MerkleProof binary structure
+      (without proofs and bitmap) */
+    uint256 internal constant _MERKLE_PROOF_SIZE = 103;
 
     /**
     @notice This function is for deserializing the MerkleProof struct from a
@@ -32,13 +31,13 @@ library MerkleProofParserLibrary {
         returns (MerkleProof memory mProof)
     {
         require(
-            src.length >= MERKLE_PROOF_SIZE,
+            src.length >= _MERKLE_PROOF_SIZE,
             "MerkleProofParserLibrary: Not enough bytes to extract a minimum MerkleProof"
         );
         uint16 bitmapLength = BaseParserLibrary.extractUInt16FromBigEndian(src, 99);
         uint16 auditPathLength = BaseParserLibrary.extractUInt16FromBigEndian(src, 101);
         require(
-            src.length >= MERKLE_PROOF_SIZE + bitmapLength + auditPathLength * 32,
+            src.length >= _MERKLE_PROOF_SIZE + bitmapLength + auditPathLength * 32,
             "MerkleProofParserLibrary: Not enough bytes to extract MerkleProof"
         );
         mProof.included = BaseParserLibrary.extractBool(src, 0);

--- a/bridge/contracts/libraries/parsers/PClaimsParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/PClaimsParserLibrary.sol
@@ -7,17 +7,16 @@ import "./RCertParserLibrary.sol";
 
 /// @title Library to parse the PClaims structure from a blob of capnproto data
 library PClaimsParserLibrary {
-    /** @dev size in bytes of a PCLAIMS cap'npro structure without the cap'n
-      proto header bytes*/
-    uint256 internal constant PCLAIMS_SIZE = 456;
-    /** @dev Number of bytes of a capnproto header, the data starts after the
-      header */
-    uint256 internal constant CAPNPROTO_HEADER_SIZE = 8;
-
     struct PClaims {
         BClaimsParserLibrary.BClaims bClaims;
         RCertParserLibrary.RCert rCert;
     }
+    /** @dev size in bytes of a PCLAIMS cap'npro structure without the cap'n
+      proto header bytes*/
+    uint256 internal constant _PCLAIMS_SIZE = 456;
+    /** @dev Number of bytes of a capnproto header, the data starts after the
+      header */
+    uint256 internal constant _CAPNPROTO_HEADER_SIZE = 8;
 
     /**
     @notice This function is for deserializing data directly from capnproto
@@ -28,7 +27,7 @@ library PClaimsParserLibrary {
     /// @return pClaims the PClaims struct
     /// @dev Execution cost: 7725 gas
     function extractPClaims(bytes memory src) internal pure returns (PClaims memory pClaims) {
-        (pClaims, ) = extractInnerPClaims(src, CAPNPROTO_HEADER_SIZE);
+        (pClaims, ) = extractInnerPClaims(src, _CAPNPROTO_HEADER_SIZE);
     }
 
     /**
@@ -53,14 +52,14 @@ library PClaimsParserLibrary {
         returns (PClaims memory pClaims, uint256 pClaimsBinarySize)
     {
         require(
-            dataOffset + PCLAIMS_SIZE > dataOffset,
+            dataOffset + _PCLAIMS_SIZE > dataOffset,
             "PClaimsParserLibrary: Overflow on the dataOffset parameter"
         );
         uint16 pointerOffsetAdjustment = BClaimsParserLibrary.getPointerOffsetAdjustment(
             src,
             dataOffset + 4
         );
-        pClaimsBinarySize = PCLAIMS_SIZE - pointerOffsetAdjustment;
+        pClaimsBinarySize = _PCLAIMS_SIZE - pointerOffsetAdjustment;
         require(
             src.length >= dataOffset + pClaimsBinarySize,
             "PClaimsParserLibrary: Not enough bytes to extract PClaims"
@@ -72,7 +71,7 @@ library PClaimsParserLibrary {
         );
         pClaims.rCert = RCertParserLibrary.extractInnerRCert(
             src,
-            dataOffset + 16 + BClaimsParserLibrary.BCLAIMS_SIZE - pointerOffsetAdjustment
+            dataOffset + 16 + BClaimsParserLibrary._BCLAIMS_SIZE - pointerOffsetAdjustment
         );
     }
 }

--- a/bridge/contracts/libraries/parsers/RCertParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/RCertParserLibrary.sol
@@ -6,20 +6,20 @@ import "./RClaimsParserLibrary.sol";
 
 /// @title Library to parse the RCert structure from a blob of capnproto data
 library RCertParserLibrary {
-    /** @dev size in bytes of a RCert cap'npro structure without the cap'n proto
-      header bytes */
-    uint256 internal constant RCERT_SIZE = 264;
-    /** @dev Number of bytes of a capnproto header, the data starts after the
-      header */
-    uint256 internal constant CAPNPROTO_HEADER_SIZE = 8;
-    /** @dev Number of Bytes of the sig group array */
-    uint256 internal constant SIG_GROUP_SIZE = 192;
-
     struct RCert {
         RClaimsParserLibrary.RClaims rClaims;
         uint256[4] sigGroupPublicKey;
         uint256[2] sigGroupSignature;
     }
+
+    /** @dev size in bytes of a RCert cap'npro structure without the cap'n proto
+      header bytes */
+    uint256 internal constant _RCERT_SIZE = 264;
+    /** @dev Number of bytes of a capnproto header, the data starts after the
+      header */
+    uint256 internal constant _CAPNPROTO_HEADER_SIZE = 8;
+    /** @dev Number of Bytes of the sig group array */
+    uint256 internal constant _SIG_GROUP_SIZE = 192;
 
     /// @notice Extracts the signature group out of a Capn Proto blob.
     /// @param src Binary data containing signature group data
@@ -33,14 +33,14 @@ library RCertParserLibrary {
         returns (uint256[4] memory publicKey, uint256[2] memory signature)
     {
         require(
-            dataOffset + RCertParserLibrary.SIG_GROUP_SIZE > dataOffset,
+            dataOffset + RCertParserLibrary._SIG_GROUP_SIZE > dataOffset,
             "RClaimsParserLibrary: Overflow on the dataOffset parameter"
         );
         require(
-            src.length >= dataOffset + RCertParserLibrary.SIG_GROUP_SIZE,
+            src.length >= dataOffset + RCertParserLibrary._SIG_GROUP_SIZE,
             "RCertParserLibrary: Not enough bytes to extract"
         );
-        // SIG_GROUP_SIZE = 192 bytes -> size in bytes of 6 uint256/bytes32 elements (6*32)
+        // _SIG_GROUP_SIZE = 192 bytes -> size in bytes of 6 uint256/bytes32 elements (6*32)
         publicKey[0] = BaseParserLibrary.extractUInt256(src, dataOffset + 0);
         publicKey[1] = BaseParserLibrary.extractUInt256(src, dataOffset + 32);
         publicKey[2] = BaseParserLibrary.extractUInt256(src, dataOffset + 64);
@@ -60,7 +60,7 @@ library RCertParserLibrary {
     /// @return the RCert struct
     /// @dev Execution cost: 4076 gas
     function extractRCert(bytes memory src) internal pure returns (RCert memory) {
-        return extractInnerRCert(src, CAPNPROTO_HEADER_SIZE);
+        return extractInnerRCert(src, _CAPNPROTO_HEADER_SIZE);
     }
 
     /**
@@ -79,11 +79,11 @@ library RCertParserLibrary {
         returns (RCert memory rCert)
     {
         require(
-            dataOffset + RCERT_SIZE > dataOffset,
+            dataOffset + _RCERT_SIZE > dataOffset,
             "RCertParserLibrary: Overflow on the dataOffset parameter"
         );
         require(
-            src.length >= dataOffset + RCERT_SIZE,
+            src.length >= dataOffset + _RCERT_SIZE,
             "RCertParserLibrary: Not enough bytes to extract RCert"
         );
         rCert.rClaims = RClaimsParserLibrary.extractInnerRClaims(src, dataOffset + 16);

--- a/bridge/contracts/libraries/parsers/RClaimsParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/RClaimsParserLibrary.sol
@@ -5,19 +5,19 @@ import "./BaseParserLibrary.sol";
 
 /// @title Library to parse the RClaims structure from a blob of capnproto data
 library RClaimsParserLibrary {
-    /** @dev size in bytes of a RCLAIMS cap'npro structure without the cap'n
-      proto header bytes*/
-    uint256 internal constant RCLAIMS_SIZE = 56;
-    /** @dev Number of bytes of a capnproto header, the data starts after the
-      header */
-    uint256 internal constant CAPNPROTO_HEADER_SIZE = 8;
-
     struct RClaims {
         uint32 chainId;
         uint32 height;
         uint32 round;
         bytes32 prevBlock;
     }
+
+    /** @dev size in bytes of a RCLAIMS cap'npro structure without the cap'n
+      proto header bytes*/
+    uint256 internal constant _RCLAIMS_SIZE = 56;
+    /** @dev Number of bytes of a capnproto header, the data starts after the
+      header */
+    uint256 internal constant _CAPNPROTO_HEADER_SIZE = 8;
 
     /**
     @notice This function is for deserializing data directly from capnproto
@@ -29,7 +29,7 @@ library RClaimsParserLibrary {
     /// @param src Binary data containing a RClaims serialized struct with Capn Proto headers
     /// @dev Execution cost: 1506 gas
     function extractRClaims(bytes memory src) internal pure returns (RClaims memory rClaims) {
-        return extractInnerRClaims(src, CAPNPROTO_HEADER_SIZE);
+        return extractInnerRClaims(src, _CAPNPROTO_HEADER_SIZE);
     }
 
     /**
@@ -47,11 +47,11 @@ library RClaimsParserLibrary {
         returns (RClaims memory rClaims)
     {
         require(
-            dataOffset + RCLAIMS_SIZE > dataOffset,
+            dataOffset + _RCLAIMS_SIZE > dataOffset,
             "RClaimsParserLibrary: Overflow on the dataOffset parameter"
         );
         require(
-            src.length >= dataOffset + RCLAIMS_SIZE,
+            src.length >= dataOffset + _RCLAIMS_SIZE,
             "RClaimsParserLibrary: Not enough bytes to extract RClaims"
         );
         rClaims.chainId = BaseParserLibrary.extractUInt32(src, dataOffset);

--- a/bridge/contracts/libraries/parsers/TXInPreImageParserLibrary.sol
+++ b/bridge/contracts/libraries/parsers/TXInPreImageParserLibrary.sol
@@ -5,18 +5,17 @@ import "./BaseParserLibrary.sol";
 
 /// @title Library to parse the TXInPreImage structure from a blob of capnproto data
 library TXInPreImageParserLibrary {
-    /** @dev size in bytes of a TXInPreImage cap'npro structure without the cap'n
-      proto header bytes*/
-    uint256 internal constant TX_IN_PRE_IMAGE_SIZE = 48;
-    /** @dev Number of bytes of a capnproto header, the data starts after the
-      header */
-    uint256 internal constant CAPNPROTO_HEADER_SIZE = 8;
-
     struct TXInPreImage {
         uint32 chainId;
         uint32 consumedTxIdx;
         bytes32 consumedTxHash; //todo: is always 32 bytes?
     }
+    /** @dev size in bytes of a TXInPreImage cap'npro structure without the cap'n
+      proto header bytes*/
+    uint256 internal constant _TX_IN_PRE_IMAGE_SIZE = 48;
+    /** @dev Number of bytes of a capnproto header, the data starts after the
+      header */
+    uint256 internal constant _CAPNPROTO_HEADER_SIZE = 8;
 
     /**
     @notice This function is for deserializing data directly from capnproto
@@ -29,7 +28,7 @@ library TXInPreImageParserLibrary {
     /// @dev Execution cost: 1120 gas
     /// @return a TXInPreImage struct
     function extractTXInPreImage(bytes memory src) internal pure returns (TXInPreImage memory) {
-        return extractInnerTXInPreImage(src, CAPNPROTO_HEADER_SIZE);
+        return extractInnerTXInPreImage(src, _CAPNPROTO_HEADER_SIZE);
     }
 
     /**
@@ -48,11 +47,11 @@ library TXInPreImageParserLibrary {
         returns (TXInPreImage memory txInPreImage)
     {
         require(
-            dataOffset + TX_IN_PRE_IMAGE_SIZE > dataOffset,
+            dataOffset + _TX_IN_PRE_IMAGE_SIZE > dataOffset,
             "TXInPreImageParserLibrary: Overflow on the dataOffset parameter"
         );
         require(
-            src.length >= dataOffset + TX_IN_PRE_IMAGE_SIZE,
+            src.length >= dataOffset + _TX_IN_PRE_IMAGE_SIZE,
             "TXInPreImageParserLibrary: Not enough bytes to extract TXInPreImage"
         );
         txInPreImage.chainId = BaseParserLibrary.extractUInt32(src, dataOffset);

--- a/bridge/contracts/libraries/validatorPool/ValidatorPoolStorage.sol
+++ b/bridge/contracts/libraries/validatorPool/ValidatorPoolStorage.sol
@@ -13,15 +13,15 @@ abstract contract ValidatorPoolStorage is
     ImmutableValidatorNFT,
     ImmutableMadToken
 {
-    // _positionLockPeriod describes the maximum interval a STAKENFT Position may be locked after
+    // POSITION_LOCK_PERIOD describes the maximum interval a STAKENFT Position may be locked after
     // being given back to validator exiting the pool
-    uint256 public constant _positionLockPeriod = 172800;
+    uint256 public constant POSITION_LOCK_PERIOD = 172800;
     // Interval in Madnet Epochs that a validator exiting the pool should before claiming is
     // STAKENFT position
-    uint256 public constant _claimPeriod = 3;
+    uint256 public constant CLAIM_PERIOD = 3;
 
     // Maximum number the ethereum blocks allowed without a validator committing a snapshot
-    uint256 public constant _maxIntervalWithoutSnapshot = 8192;
+    uint256 public constant MAX_INTERVAL_WITHOUT_SNAPSHOTS = 8192;
 
     // address internal immutable _factory;
     // INFTStake internal immutable _stakeNFT;
@@ -48,7 +48,7 @@ abstract contract ValidatorPoolStorage is
     ValidatorDataMap internal _validators;
 
     // Mapping that keeps track of the validators leaving the Pool. Validators assets are hold by
-    // `_claimPeriod` epochs before the user being able to claim the assets back in the form a new
+    // `CLAIM_PERIOD` epochs before the user being able to claim the assets back in the form a new
     // STAKENFT position.
     mapping(address => ExitingValidatorData) internal _exitingValidatorsData;
 

--- a/bridge/contracts/utils/Admin.sol
+++ b/bridge/contracts/utils/Admin.sol
@@ -5,19 +5,19 @@ abstract contract Admin {
     // _admin is a privileged role
     address internal _admin;
 
-    constructor(address admin_) {
-        _admin = admin_;
-    }
-
     /// @dev onlyAdmin enforces msg.sender is _admin
     modifier onlyAdmin() {
         require(msg.sender == _admin, "Must be admin");
         _;
     }
 
-    // assigns a new admin may only be called by _admin
-    function _setAdmin(address admin_) internal {
+    constructor(address admin_) {
         _admin = admin_;
+    }
+
+    /// @dev assigns a new admin may only be called by _admin
+    function setAdmin(address admin_) public virtual onlyAdmin {
+        _setAdmin(admin_);
     }
 
     /// @dev getAdmin returns the current _admin
@@ -25,8 +25,8 @@ abstract contract Admin {
         return _admin;
     }
 
-    /// @dev assigns a new admin may only be called by _admin
-    function setAdmin(address admin_) public virtual onlyAdmin {
-        _setAdmin(admin_);
+    // assigns a new admin may only be called by _admin
+    function _setAdmin(address admin_) internal {
+        _admin = admin_;
     }
 }

--- a/bridge/contracts/utils/AtomicCounter.sol
+++ b/bridge/contracts/utils/AtomicCounter.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 abstract contract AtomicCounter {
     // monotonically increasing counter
-    uint256 _counter = 0;
+    uint256 internal _counter = 0;
 
     // _newTokenID increments the counter and returns the new value
     function _increment() internal returns (uint256 count) {

--- a/bridge/contracts/utils/CircuitBreaker.sol
+++ b/bridge/contracts/utils/CircuitBreaker.sol
@@ -2,17 +2,17 @@
 pragma solidity ^0.8.0;
 
 abstract contract CircuitBreaker {
-    bool constant open = true;
-    bool constant closed = false;
+    bool internal constant _OPEN = true;
+    bool internal constant _CLOSED = false;
 
     // cb is the circuit breaker
     // cb is a set only object
-    bool _cb = closed;
+    bool internal _cb = _CLOSED;
 
     // withCB is a modifier to enforce the CB must
     // be set for a call to succeed
     modifier withCB() {
-        require(_cb == closed, "CircuitBreaker: The Circuit breaker is opened!");
+        require(_cb == _CLOSED, "CircuitBreaker: The Circuit breaker is opened!");
         _;
     }
 
@@ -21,12 +21,12 @@ abstract contract CircuitBreaker {
     }
 
     function _tripCB() internal {
-        require(_cb == closed, "CircuitBreaker: The Circuit breaker is opened!");
-        _cb = open;
+        require(_cb == _CLOSED, "CircuitBreaker: The Circuit breaker is opened!");
+        _cb = _OPEN;
     }
 
     function _resetCB() internal {
-        require(_cb == open, "CircuitBreaker: The Circuit breaker is closed!");
-        _cb = closed;
+        require(_cb == _OPEN, "CircuitBreaker: The Circuit breaker is CLOSED!");
+        _cb = _CLOSED;
     }
 }

--- a/bridge/contracts/utils/ImmutableAuth.sol
+++ b/bridge/contracts/utils/ImmutableAuth.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT-open-group
 pragma solidity ^0.8.11;
-
+/* solhint-disable */
 import "./DeterministicAddress.sol";
 
 abstract contract ImmutableFactory is DeterministicAddress {
@@ -307,3 +307,4 @@ abstract contract ImmutableFoundation is ImmutableFactory {
         return 0x466f756e646174696f6e00000000000000000000000000000000000000000000;
     }
 }
+/* solhint-enable */

--- a/bridge/contracts/utils/MagicValue.sol
+++ b/bridge/contracts/utils/MagicValue.sol
@@ -2,18 +2,18 @@
 pragma solidity ^0.8.0;
 
 abstract contract MagicValue {
-    // _magicValue is a constant that may be used to prevent
+    // _MAGIC_VALUE is a constant that may be used to prevent
     // a user from calling a dangerous method without significant
     // effort or ( hopefully ) reading the code to understand the risk
-    uint8 constant _magicValue = 42;
-
-    // _getMagic returns the magic constant
-    function _getMagic() internal pure returns (uint8) {
-        return _magicValue;
-    }
+    uint8 internal constant _MAGIC_VALUE = 42;
 
     modifier checkMagic(uint8 magic_) {
         require(magic_ == _getMagic(), "BAD MAGIC");
         _;
+    }
+
+    // _getMagic returns the magic constant
+    function _getMagic() internal pure returns (uint8) {
+        return _MAGIC_VALUE;
     }
 }

--- a/bridge/contracts/utils/Mutex.sol
+++ b/bridge/contracts/utils/Mutex.sol
@@ -2,18 +2,18 @@
 pragma solidity ^0.8.0;
 
 abstract contract Mutex {
-    uint256 constant LOCKED = 1;
-    uint256 constant UNLOCKED = 2;
-    uint256 _mutex;
-
-    constructor() {
-        _mutex = UNLOCKED;
-    }
+    uint256 internal constant _LOCKED = 1;
+    uint256 internal constant _UNLOCKED = 2;
+    uint256 internal _mutex;
 
     modifier withLock() {
-        require(_mutex != LOCKED, "Mutex: Couldn't acquire the lock!");
-        _mutex = LOCKED;
+        require(_mutex != _LOCKED, "Mutex: Couldn't acquire the lock!");
+        _mutex = _LOCKED;
         _;
-        _mutex = UNLOCKED;
+        _mutex = _UNLOCKED;
+    }
+
+    constructor() {
+        _mutex = _UNLOCKED;
     }
 }

--- a/bridge/contracts/utils/Utils.sol
+++ b/bridge/contracts/utils/Utils.sol
@@ -10,19 +10,19 @@ contract Utils {
         return csize;
     }
 
-    function getCode(address _addr) public view returns (bytes memory o_code) {
+    function getCode(address addr_) public view returns (bytes memory outputCode) {
         assembly {
             // retrieve the size of the code, this needs assembly
-            let size := extcodesize(_addr)
+            let size := extcodesize(addr_)
             // allocate output byte array - this could also be done without assembly
-            // by using o_code = new bytes(size)
-            o_code := mload(0x40)
+            // by using outputCode = new bytes(size)
+            outputCode := mload(0x40)
             // new "memory end" including padding
-            mstore(0x40, add(o_code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
+            mstore(0x40, add(outputCode, and(add(add(size, 0x20), 0x1f), not(0x1f))))
             // store length in memory
-            mstore(o_code, size)
+            mstore(outputCode, size)
             // actually retrieve the code, this needs assembly
-            extcodecopy(_addr, add(o_code, 0x20), 0, size)
+            extcodecopy(addr_, add(outputCode, 0x20), 0, size)
         }
     }
 }

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -8,7 +8,7 @@
     "clean": "mkdir -p typechain-types && rm -rf typechain-types && hardhat clean && mkdir -p bindings && rm -rf bindings && mkdir -p artifacts && rm -rf artifacts ",
     "build": "hardhat compile && hardhat go-go-gen --out bindings --pkg bindings --in bindings/bindings-artifacts && ./bindings/generate.sh",
     "format": "prettier --write './**/*.sol' './**/*.ts' './**/*.test.ts' './**/*.js' './**/*.json'",
-    "linter": "solhint 'contracts/**/*.sol'"
+    "linter": "solhint 'contracts/**/*.sol' 'test/**/*.sol'"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -2,12 +2,13 @@
   "name": "bridge",
   "version": "0.1.0",
   "scripts": {
-    "init": "npx hardhat typechain",
-    "test": "npx hardhat test --show-stack-traces",
-    "test-parallel": "npx hardhat test --parallel --show-stack-traces",
-    "clean": "mkdir -p typechain-types && rm -rf typechain-types && npx hardhat clean && mkdir -p bindings && rm -rf bindings && mkdir -p artifacts && rm -rf artifacts ",
-    "build": "npx hardhat compile && npx hardhat go-go-gen --out bindings --pkg bindings --in bindings/bindings-artifacts && ./bindings/generate.sh",
-    "format": "prettier --write './**/*.sol' './**/*.ts' './**/*.test.ts' './**/*.js' './**/*.json'"
+    "init": "hardhat typechain",
+    "test": "hardhat test --show-stack-traces",
+    "test-parallel": "hardhat test --parallel --show-stack-traces",
+    "clean": "mkdir -p typechain-types && rm -rf typechain-types && hardhat clean && mkdir -p bindings && rm -rf bindings && mkdir -p artifacts && rm -rf artifacts ",
+    "build": "hardhat compile && hardhat go-go-gen --out bindings --pkg bindings --in bindings/bindings-artifacts && ./bindings/generate.sh",
+    "format": "prettier --write './**/*.sol' './**/*.ts' './**/*.test.ts' './**/*.js' './**/*.json'",
+    "linter": "solhint 'contracts/**/*.sol'"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/bridge/test/contract-mocks/ethdkg/ETHDKGMock.sol
+++ b/bridge/test/contract-mocks/ethdkg/ETHDKGMock.sol
@@ -157,7 +157,7 @@ contract ETHDKGMock is
     }
 
     function getMinValidators() public pure returns (uint256) {
-        return MIN_VALIDATOR;
+        return _MIN_VALIDATORS;
     }
 
     function getParticipantInternalState(address participant)
@@ -230,7 +230,7 @@ contract ETHDKGMock is
         //todo: should we reward ppl here?
         uint256 numberValidators = IValidatorPool(_ValidatorPoolAddress()).getValidatorsCount();
         require(
-            numberValidators >= MIN_VALIDATOR,
+            numberValidators >= _MIN_VALIDATORS,
             "ETHDKG: Minimum number of validators staked not met!"
         );
 

--- a/bridge/test/contract-mocks/factory/MockBaseContract.sol
+++ b/bridge/test/contract-mocks/factory/MockBaseContract.sol
@@ -3,21 +3,39 @@ pragma solidity ^0.8.11;
 import "contracts/libraries/proxy/ProxyInternalUpgradeLock.sol";
 import "contracts/libraries/proxy/ProxyInternalUpgradeUnlock.sol";
 
-/// @custom:salt Mock
-contract MockBaseContract is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlock {
-    address factory_;
-    uint256 public v;
-    uint256 public immutable i;
-    string p;
+interface IMockBaseContract {
+    function setV(uint256 _v) external;
 
-    constructor(uint256 _i, string memory _p) {
-        p = _p;
-        i = _i;
-        factory_ = msg.sender;
+    function lock() external;
+
+    function unlock() external;
+
+    function fail() external;
+
+    function getVar() external view returns (uint256);
+
+    function getImut() external view returns (uint256);
+}
+
+/// @custom:salt Mock
+contract MockBaseContract is
+    ProxyInternalUpgradeLock,
+    ProxyInternalUpgradeUnlock,
+    IMockBaseContract
+{
+    address internal _factory;
+    uint256 internal _var;
+    uint256 internal immutable _imut;
+    string internal _pString;
+
+    constructor(uint256 imut_, string memory pString_) {
+        _pString = pString_;
+        _imut = imut_;
+        _factory = msg.sender;
     }
 
-    function setv(uint256 _v) public {
-        v = _v;
+    function setV(uint256 _v) public {
+        _var = _v;
     }
 
     function lock() public {
@@ -28,25 +46,23 @@ contract MockBaseContract is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnloc
         __unlockImplementation();
     }
 
-    function setFactory(address _factory) public {
-        factory_ = _factory;
+    function setFactory(address factory_) public {
+        _factory = factory_;
     }
 
-    function getFactory() external view returns (address) {
-        return factory_;
+    function getFactory() public view returns (address) {
+        return _factory;
     }
-}
 
-interface IMockBaseContract {
-    function v() external returns (uint256);
+    function getImut() public view returns (uint256) {
+        return _imut;
+    }
 
-    function i() external returns (uint256);
+    function getVar() public view returns (uint256) {
+        return _var;
+    }
 
-    function setv(uint256 _v) external;
-
-    function lock() external;
-
-    function unlock() external;
-
-    function fail() external;
+    function fail() public pure {
+        require(false == true, "Failed!");
+    }
 }

--- a/bridge/test/contract-mocks/factory/MockEndPoint.sol
+++ b/bridge/test/contract-mocks/factory/MockEndPoint.sol
@@ -2,35 +2,36 @@
 pragma solidity ^0.8.11;
 
 interface IMockEndPoint {
-    function i() external view returns (uint256);
-
     function addOne() external;
 
     function addTwo() external;
 
     function factory() external returns (address);
+
+    function i() external view returns (uint256);
 }
 
 /// @custom:salt MockEndPoint
-contract MockEndPoint {
-    address public immutable factory_;
+contract MockEndPoint is IMockEndPoint {
+    address public immutable factory;
     address public owner;
     uint256 public i;
-    event addedOne(uint256 indexed i);
-    event addedTwo(uint256 indexed i);
+
+    event AddedOne(uint256 indexed i);
+    event AddedTwo(uint256 indexed i);
     event UpgradeLock(bool indexed lock);
 
     constructor(address f) {
-        factory_ = f;
+        factory = f;
     }
 
     function addOne() public {
         i++;
-        emit addedOne(i);
+        emit AddedOne(i);
     }
 
     function addTwo() public {
         i = i + 2;
-        emit addedTwo(i);
+        emit AddedTwo(i);
     }
 }

--- a/bridge/test/contract-mocks/factory/MockEndPointLockable.sol
+++ b/bridge/test/contract-mocks/factory/MockEndPointLockable.sol
@@ -6,54 +6,64 @@ import "contracts/libraries/proxy/ProxyInternalUpgradeLock.sol";
 import "contracts/libraries/proxy/ProxyInternalUpgradeUnlock.sol";
 
 interface IMockEndPointLockable {
-    function i() external view returns (uint256);
-
     function addOne() external;
 
     function addTwo() external;
 
     function factory() external returns (address);
+
+    function i() external view returns (uint256);
 }
 
 /// @custom:salt MockEndPointLockable
-contract MockEndPointLockable is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlock {
-    address private immutable factory_;
+contract MockEndPointLockable is
+    ProxyInternalUpgradeLock,
+    ProxyInternalUpgradeUnlock,
+    IMockEndPointLockable
+{
+    address private immutable _factory;
     address public owner;
     uint256 public i;
+
+    event AddedOne(uint256 indexed i);
+    event AddedTwo(uint256 indexed i);
+    event UpgradeLocked(bool indexed lock);
+    event UpgradeUnlocked(bool indexed lock);
+
     modifier onlyOwner() {
         _requireAuth(msg.sender == owner);
         _;
     }
-    event addedOne(uint256 indexed i);
-    event addedTwo(uint256 indexed i);
-    event upgradeLocked(bool indexed lock);
-    event upgradeUnlocked(bool indexed lock);
 
     constructor(address f) {
-        factory_ = f;
+        _factory = f;
     }
 
     function addOne() public {
         i++;
-        emit addedOne(i);
+        emit AddedOne(i);
     }
 
     function addTwo() public {
         i = i + 2;
-        emit addedTwo(i);
+        emit AddedTwo(i);
     }
 
     function upgradeLock() public {
         __lockImplementation();
-        emit upgradeLocked(true);
+        emit UpgradeLocked(true);
     }
 
     function upgradeUnlock() public {
         __unlockImplementation();
-        emit upgradeUnlocked(false);
+        emit UpgradeUnlocked(false);
     }
 
-    function _requireAuth(bool _ok) internal pure {
-        require(_ok, "unauthorized");
+    function factory() public view returns (address) {
+        return _factory;
+    }
+
+    function _requireAuth(bool isOk_) internal pure {
+        require(isOk_, "unauthorized");
     }
 }

--- a/bridge/test/contract-mocks/factory/MockEndPointLockable.sol
+++ b/bridge/test/contract-mocks/factory/MockEndPointLockable.sol
@@ -21,7 +21,7 @@ contract MockEndPointLockable is ProxyInternalUpgradeLock, ProxyInternalUpgradeU
     address public owner;
     uint256 public i;
     modifier onlyOwner() {
-        requireAuth(msg.sender == owner);
+        _requireAuth(msg.sender == owner);
         _;
     }
     event addedOne(uint256 indexed i);
@@ -53,7 +53,7 @@ contract MockEndPointLockable is ProxyInternalUpgradeLock, ProxyInternalUpgradeU
         emit upgradeUnlocked(false);
     }
 
-    function requireAuth(bool _ok) internal pure {
+    function _requireAuth(bool _ok) internal pure {
         require(_ok, "unauthorized");
     }
 }

--- a/bridge/test/contract-mocks/factory/MockFactory.sol
+++ b/bridge/test/contract-mocks/factory/MockFactory.sol
@@ -7,24 +7,24 @@ contract MockFactory is DeterministicAddress, ProxyUpgrader {
     /**
     @dev owner role for priveledged access to functions
     */
-    address private owner_;
+    address private _owner;
 
     /**
     @dev delegator role for priveledged access to delegateCallAny
     */
-    address private delegator_;
+    address private _delegator;
 
     /**
     @dev array to store list of contract salts
     */
-    bytes32[] private contracts_;
+    bytes32[] private _contracts;
 
     /**
     @dev slot for storing implementation address
     */
-    address private implementation_;
+    address private _implementation;
 
-    function setOwner(address _new) public {
-        owner_ = _new;
+    function setOwner(address new_) public {
+        _owner = new_;
     }
 }

--- a/bridge/test/contract-mocks/factory/MockInitializable.sol
+++ b/bridge/test/contract-mocks/factory/MockInitializable.sol
@@ -3,10 +3,16 @@ pragma solidity ^0.8.11;
 import "contracts/libraries/proxy/ProxyInternalUpgradeLock.sol";
 import "contracts/libraries/proxy/ProxyInternalUpgradeUnlock.sol";
 
-contract MockInitializable is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlock {
-    address factory_;
-    uint256 public v;
-    uint256 public i;
+import "test/contract-mocks/factory/MockBaseContract.sol";
+
+contract MockInitializable is
+    ProxyInternalUpgradeLock,
+    ProxyInternalUpgradeUnlock,
+    IMockBaseContract
+{
+    address internal _factory;
+    uint256 internal _var;
+    uint256 internal _imut;
     address public immutable factoryAddress = 0x0BBf39118fF9dAfDC8407c507068D47572623069;
     /**
      * @dev Indicates that the contract has been initialized.
@@ -52,33 +58,20 @@ contract MockInitializable is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlo
         _;
     }
 
-    function isContract(address account) internal view returns (bool) {
-        // This method relies on extcodesize/address.code.length, which returns 0
-        // for contracts in construction, since the code is only stored at the end
-        // of the constructor execution.
-
-        return account.code.length > 0;
+    function getFactory() external view returns (address) {
+        return _factory;
     }
 
-    function _isConstructor() private view returns (bool) {
-        return !isContract(address(this));
+    function initialize(uint256 i_) public virtual initializer {
+        __mockInit(i_);
     }
 
-    function initialize(uint256 _i) public virtual initializer {
-        __Mock_init(_i);
+    function setFactory(address factory_) public {
+        _factory = factory_;
     }
 
-    function __Mock_init(uint256 _i) internal onlyInitializing {
-        __Mock_init_unchained(_i);
-    }
-
-    function __Mock_init_unchained(uint256 _i) internal onlyInitializing {
-        i = _i;
-        factory_ = msg.sender;
-    }
-
-    function setv(uint256 _v) public {
-        v = _v;
+    function setV(uint256 _v) public {
+        _var = _v;
     }
 
     function lock() public {
@@ -89,11 +82,36 @@ contract MockInitializable is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlo
         __unlockImplementation();
     }
 
-    function setFactory(address _factory) public {
-        factory_ = _factory;
+    function getVar() public view returns (uint256) {
+        return _var;
     }
 
-    function getFactory() external view returns (address) {
-        return factory_;
+    function getImut() public view returns (uint256) {
+        return _imut;
+    }
+
+    function fail() public pure {
+        require(false == true, "Failed!");
+    }
+
+    function __mockInit(uint256 i_) internal onlyInitializing {
+        __mockInitUnchained(i_);
+    }
+
+    function __mockInitUnchained(uint256 i_) internal onlyInitializing {
+        _imut = i_;
+        _factory = msg.sender;
+    }
+
+    function _isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return account.code.length > 0;
+    }
+
+    function _isConstructor() private view returns (bool) {
+        return !_isContract(address(this));
     }
 }

--- a/bridge/test/contract-mocks/factory/MockSelfDestruct.sol
+++ b/bridge/test/contract-mocks/factory/MockSelfDestruct.sol
@@ -5,16 +5,20 @@ import "contracts/libraries/proxy/ProxyInternalUpgradeLock.sol";
 import "contracts/libraries/proxy/ProxyInternalUpgradeUnlock.sol";
 
 contract MockSelfDestruct is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnlock {
-    address factory_;
+    address internal _factory;
     uint256 public v;
     uint256 public immutable i;
 
     constructor(uint256 _i, bytes memory) {
         i = _i;
-        factory_ = msg.sender;
+        _factory = msg.sender;
     }
 
-    function setv(uint256 _v) public {
+    function getFactory() external view returns (address) {
+        return _factory;
+    }
+
+    function setV(uint256 _v) public {
         v = _v;
     }
 
@@ -26,11 +30,7 @@ contract MockSelfDestruct is ProxyInternalUpgradeLock, ProxyInternalUpgradeUnloc
         __unlockImplementation();
     }
 
-    function setFactory(address _factory) public {
-        factory_ = _factory;
-    }
-
-    function getFactory() external view returns (address) {
-        return factory_;
+    function setFactory(address factory_) public {
+        _factory = factory_;
     }
 }

--- a/bridge/test/contract-mocks/validatorPool/ValidatorPoolMock.sol
+++ b/bridge/test/contract-mocks/validatorPool/ValidatorPoolMock.sol
@@ -38,6 +38,11 @@ contract ValidatorPoolMock is
 
     uint256 internal _stakeAmount;
 
+    modifier onlyAdmin() {
+        require(msg.sender == _admin, "Validators: requires admin privileges");
+        _;
+    }
+
     // solhint-disable no-empty-blocks
     constructor()
         ImmutableFactory(msg.sender)
@@ -52,13 +57,21 @@ contract ValidatorPoolMock is
         _stakeAmount = 20000 * 10**18;
     }
 
-    function initializeETHDKG() external {
+    function initializeETHDKG() public {
         IETHDKG(_ETHDKGAddress()).initializeETHDKG();
     }
 
-    modifier onlyAdmin() {
-        require(msg.sender == _admin, "Validators: requires admin privileges");
-        _;
+    function setDisputerReward(uint256 disputerReward_) public {}
+
+    function pauseConsensusOnArbitraryHeight(uint256 madnetHeight_) public onlyFactory {
+        require(
+            block.number >
+                ISnapshots(_SnapshotsAddress()).getCommittedHeightFromLatestSnapshot() +
+                    MAX_INTERVAL_WITHOUT_SNAPSHOTS,
+            "ValidatorPool: Condition not met to stop consensus!"
+        );
+        _isConsensusRunning = false;
+        IETHDKG(_ETHDKGAddress()).setCustomMadnetHeight(madnetHeight_);
     }
 
     function mintValidatorNFT() public returns (uint256 stakeID_) {
@@ -95,47 +108,6 @@ contract ValidatorPoolMock is
         return INFTStake(_ValidatorNFTAddress()).burnTo(to_, tokenID_);
     }
 
-    function isValidator(address participant) public view returns (bool) {
-        return _isValidator(participant);
-    }
-
-    function _isValidator(address participant) internal view returns (bool) {
-        return _validators.contains(participant);
-    }
-
-    function getStakeAmount() public view returns (uint256) {
-        return _stakeAmount;
-    }
-
-    function getMaxNumValidators() public pure returns (uint256) {
-        return 5;
-    }
-
-    function getDisputerReward() public pure returns (uint256) {
-        return 1;
-    }
-
-    function registerValidators(address[] memory v) internal {
-        for (uint256 idx; idx < v.length; idx++) {
-            uint256 tokenID = _tokenIDCounter + 1;
-            _validators.add(ValidatorData(v[idx], tokenID));
-            _tokenIDCounter = tokenID;
-        }
-    }
-
-    function getValidatorsCount() public view returns (uint256) {
-        return _validators.length();
-    }
-
-    function getValidator(uint256 index_) public view returns (address) {
-        require(index_ < _validators.length(), "Index out boundaries!");
-        return _validators.at(index_)._address;
-    }
-
-    function getValidatorsAddresses() external view returns (address[] memory addresses) {
-        return _validators.addressValues();
-    }
-
     function minorSlash(address validator, address disputer) public {
         disputer; //no-op to suppress warning of not using disputer address
         _removeValidator(validator);
@@ -158,10 +130,6 @@ contract ValidatorPoolMock is
         }
     }
 
-    function _removeValidator(address validator_) internal {
-        _validators.remove(validator_);
-    }
-
     function completeETHDKG() public {
         _isMaintenanceScheduled = false;
         _isConsensusRunning = true;
@@ -175,6 +143,46 @@ contract ValidatorPoolMock is
         _isMaintenanceScheduled = true;
     }
 
+    function setConsensusRunning(bool isRunning) public {
+        _isConsensusRunning = isRunning;
+    }
+
+    function setStakeAmount(uint256 stakeAmount_) public {}
+
+    function setSnapshot(address _address) public {}
+
+    function setMaxNumValidators(uint256 maxNumValidators_) public {}
+
+    function setLocation(string memory ip) public {}
+
+    function registerValidators(address[] memory validators, uint256[] memory stakerTokenIDs)
+        public
+    {
+        stakerTokenIDs;
+        _registerValidators(validators);
+    }
+
+    function isValidator(address participant) public view returns (bool) {
+        return _isValidator(participant);
+    }
+
+    function getStakeAmount() public view returns (uint256) {
+        return _stakeAmount;
+    }
+
+    function getValidatorsCount() public view returns (uint256) {
+        return _validators.length();
+    }
+
+    function getValidator(uint256 index_) public view returns (address) {
+        require(index_ < _validators.length(), "Index out boundaries!");
+        return _validators.at(index_)._address;
+    }
+
+    function getValidatorsAddresses() public view returns (address[] memory addresses) {
+        return _validators.addressValues();
+    }
+
     function isMaintenanceScheduled() public view returns (bool) {
         return _isMaintenanceScheduled;
     }
@@ -183,8 +191,16 @@ contract ValidatorPoolMock is
         return _isConsensusRunning;
     }
 
-    function setConsensusRunning(bool isRunning) public {
-        _isConsensusRunning = isRunning;
+    function getValidatorData(uint256 index) public view returns (ValidatorData memory) {
+        return _validators.at(index);
+    }
+
+    function getMaxNumValidators() public pure returns (uint256) {
+        return 5;
+    }
+
+    function getDisputerReward() public pure returns (uint256) {
+        return 1;
     }
 
     function claimExitingNFTPosition() public pure returns (uint256) {
@@ -208,59 +224,43 @@ contract ValidatorPoolMock is
         return (0, 0);
     }
 
-    function getLocations(address[] calldata validators_) external pure returns (string[] memory) {
+    function getLocations(address[] memory validators_) public pure returns (string[] memory) {
         validators_;
         return new string[](1);
     }
 
-    function getValidatorData(uint256 index) external view returns (ValidatorData memory) {
-        return _validators.at(index);
-    }
-
-    function setStakeAmount(uint256 stakeAmount_) external {}
-
-    function setSnapshot(address _address) external {}
-
-    function setMaxNumValidators(uint256 maxNumValidators_) public {}
-
-    function setLocation(string calldata ip) external {}
-
-    function registerValidators(address[] calldata validators, uint256[] calldata stakerTokenIDs)
-        public
-    {
-        stakerTokenIDs;
-        registerValidators(validators);
-    }
-
-    function isInExitingQueue(address participant) external pure returns (bool) {
+    function isInExitingQueue(address participant) public pure returns (bool) {
         participant;
         return false;
     }
 
-    function isAccusable(address participant) external pure returns (bool) {
+    function isAccusable(address participant) public pure returns (bool) {
         participant;
         return false;
     }
 
-    function getLocation(address validator) external pure returns (string memory) {
+    function getLocation(address validator) public pure returns (string memory) {
         validator;
         return "";
     }
-
-    function setDisputerReward(uint256 disputerReward_) public {}
 
     function isMock() public pure returns (bool) {
         return true;
     }
 
-    function pauseConsensusOnArbitraryHeight(uint256 madnetHeight_) public onlyFactory {
-        require(
-            block.number >
-                ISnapshots(_SnapshotsAddress()).getCommittedHeightFromLatestSnapshot() +
-                    MAX_INTERVAL_WITHOUT_SNAPSHOTS,
-            "ValidatorPool: Condition not met to stop consensus!"
-        );
-        _isConsensusRunning = false;
-        IETHDKG(_ETHDKGAddress()).setCustomMadnetHeight(madnetHeight_);
+    function _removeValidator(address validator_) internal {
+        _validators.remove(validator_);
+    }
+
+    function _registerValidators(address[] memory v) internal {
+        for (uint256 idx; idx < v.length; idx++) {
+            uint256 tokenID = _tokenIDCounter + 1;
+            _validators.add(ValidatorData(v[idx], tokenID));
+            _tokenIDCounter = tokenID;
+        }
+    }
+
+    function _isValidator(address participant) internal view returns (bool) {
+        return _validators.contains(participant);
     }
 }

--- a/bridge/test/contract-mocks/validatorPool/ValidatorPoolMock.sol
+++ b/bridge/test/contract-mocks/validatorPool/ValidatorPoolMock.sol
@@ -21,9 +21,9 @@ contract ValidatorPoolMock is
 {
     using CustomEnumerableMaps for ValidatorDataMap;
 
-    uint256 public constant _positionLockPeriod = 3; // Actual is 172800
+    uint256 public constant POSITION_LOCK_PERIOD = 3; // Actual is 172800
 
-    uint256 public constant _maxIntervalWithoutSnapshot = 0; // Actual is 8192
+    uint256 public constant MAX_INTERVAL_WITHOUT_SNAPSHOTS = 0; // Actual is 8192
 
     uint256 internal _tokenIDCounter;
     //IETHDKG immutable internal _ethdkg;
@@ -257,7 +257,7 @@ contract ValidatorPoolMock is
         require(
             block.number >
                 ISnapshots(_SnapshotsAddress()).getCommittedHeightFromLatestSnapshot() +
-                    _maxIntervalWithoutSnapshot,
+                    MAX_INTERVAL_WITHOUT_SNAPSHOTS,
             "ValidatorPool: Condition not met to stop consensus!"
         );
         _isConsensusRunning = false;

--- a/bridge/test/factory/APIGetters.test.ts
+++ b/bridge/test/factory/APIGetters.test.ts
@@ -36,7 +36,7 @@ describe("Madnetfactory API test", async () => {
 
   it("getters", async () => {
     await deployStatic(END_POINT, factory.address);
-    let implAddr = await factory.implementation();
+    let implAddr = await factory.getImplementation();
     expect(implAddr).to.not.be.undefined;
     let saltsArray = await factory.contracts();
     expect(saltsArray.length).to.be.greaterThan(0);

--- a/bridge/test/factory/Setup.ts
+++ b/bridge/test/factory/Setup.ts
@@ -42,12 +42,12 @@ export async function proxyMockLogicTest(
   await expectTxSuccess(txResponse);
   let fa = await mockProxy.callStatic.getFactory();
   expect(fa).to.equal(factoryAddress);
-  txResponse = await mockProxy.setv(testArg);
+  txResponse = await mockProxy.setV(testArg);
   receipt = await txResponse.wait();
   await expectTxSuccess(txResponse);
-  let v = await mockProxy.callStatic.v();
+  let v = await mockProxy.callStatic.getVar();
   expect(v.toNumber()).to.equal(testArg);
-  let i = await mockProxy.callStatic.i();
+  let i = await mockProxy.callStatic.getImut();
   expect(i.toNumber()).to.equal(2);
   //upgrade the proxy
   txResponse = await factory.upgradeProxy(salt, endPointAddr, "0x");
@@ -55,20 +55,20 @@ export async function proxyMockLogicTest(
   await expectTxSuccess(txResponse);
   //endpoint interface connected to proxy address
   let proxyEndpoint = endPointFactory.attach(proxyAddress);
-  i = await proxyEndpoint.callStatic.i();
+  i = await proxyEndpoint.i();
   let num = i.toNumber() + 2;
   txResponse = await proxyEndpoint.addTwo();
   receipt = await txResponse.wait();
-  let test = await getEventVar(txResponse, "addedTwo", "i");
+  let test = await getEventVar(txResponse, "AddedTwo", "i");
   expect(test.toNumber()).to.equal(num);
   //lock the proxy upgrade
   txResponse = await factory.upgradeProxy(salt, mockLogicAddr, "0x");
   receipt = await txResponse.wait();
   await expectTxSuccess(txResponse);
-  txResponse = await mockProxy.setv(testArg + 2);
+  txResponse = await mockProxy.setV(testArg + 2);
   receipt = await txResponse.wait();
   await expectTxSuccess(txResponse);
-  v = await mockProxy.callStatic.v();
+  v = await mockProxy.getVar();
   receipt = await txResponse.wait();
   expect(v.toNumber()).to.equal(testArg + 2);
   //lock the upgrade functionality
@@ -86,11 +86,11 @@ export async function proxyMockLogicTest(
   txResponse = await factory.upgradeProxy(salt, endPointAddr, "0x");
   receipt = await txResponse.wait();
   await expectTxSuccess(txResponse);
-  i = await proxyEndpoint.callStatic.i();
+  i = await proxyEndpoint.i();
   num = i.toNumber() + 2;
   txResponse = await proxyEndpoint.addTwo();
   receipt = await txResponse.wait();
-  test = await getEventVar(txResponse, "addedTwo", "i");
+  test = await getEventVar(txResponse, "AddedTwo", "i");
   expect(test.toNumber()).to.equal(num);
 }
 
@@ -106,12 +106,12 @@ export async function metaMockLogicTest(
   await expectTxSuccess(txResponse);
   let fa = await Contract.getFactory.call();
   expect(fa).to.equal(factoryAddress);
-  txResponse = await Contract.setv(test);
+  txResponse = await Contract.setV(test);
   receipt = await txResponse.wait();
   await expectTxSuccess(txResponse);
-  let v = await Contract.callStatic.v();
+  let v = await Contract.getVar();
   expect(v.toNumber()).to.equal(test);
-  let i = await Contract.callStatic.i();
+  let i = await Contract.getImut();
   expect(i.toNumber()).to.equal(2);
 }
 
@@ -201,7 +201,7 @@ export async function getDeployStaticArgs(
 export async function checkMockInit(target: string, initVal: number) {
   let mockFactory = await ethers.getContractFactory(MOCK);
   let mock = await mockFactory.attach(target);
-  let i = await mock.callStatic.i();
+  let i = await mock.getImut();
   expect(i.toNumber()).to.equal(initVal);
 }
 

--- a/bridge/test/validatorPool/business-logic/consensus-dependent-functions.test.ts
+++ b/bridge/test/validatorPool/business-logic/consensus-dependent-functions.test.ts
@@ -53,7 +53,7 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
   });
 
   it("Pause consensus after 1.5 days without snapshot.", async function () {
-    // Simulating in mock with _maxIntervalWithoutSnapshot = 0 instead of 8192
+    // Simulating in mock with MAX_INTERVAL_WITHOUT_SNAPSHOTS = 0 instead of 8192
     fixture = await getFixture(true, true, true);
     await factoryCallAny(
       fixture,
@@ -64,7 +64,7 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
   });
 
   it("After 1.5 days without snapshots, replace validators and run ETHDKG to completion.", async function () {
-    // Simulating in mock with _maxIntervalWithoutSnapshot = 0 instead of 8192
+    // Simulating in mock with MAX_INTERVAL_WITHOUT_SNAPSHOTS = 0 instead of 8192
     fixture = await getFixture(true, true, true);
     validators = await createValidators(fixture, validatorsSnapshots);
     stakingTokenIds = await stakeValidators(fixture, validators);


### PR DESCRIPTION
## Scope

This PR is:
- changing all solidity files (in contracts and test folder) to conform to the official solidity naming convention /style guide. See documentation [here](https://docs.soliditylang.org/en/v0.8.12/style-guide.html).
- adding solhint as default solidity linter
- adding a new npm command to run the linter. To run the linter, just run `npm run linter`
- updating madnet Factory and madnetFactoryBase code documentation
