### PR TITLE
Fix edge case bug in the slashing logic

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -31,3 +31,4 @@ bindings-artifacts/*
 bindings/generate.go
 !deployments/dev/deploymentArgsTemplate.json
 !deployments/dev/deployList.json
+**/generated/*

--- a/bridge/.npmrc
+++ b/bridge/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/bridge/.prettierrc
+++ b/bridge/.prettierrc
@@ -22,6 +22,15 @@
       }
     },
     {
+      "files": "*.prettierrc",
+      "options": {
+        "tabWidth": 2,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": false
+      }
+    },
+    {
       "files": "*.ts",
       "options": {
         "tabWidth": 2,

--- a/bridge/.solhint.json
+++ b/bridge/.solhint.json
@@ -8,7 +8,7 @@
     "no-unused-vars": "warn",
     "payable-fallback": "warn",
     "reason-string": ["warn", {"maxLength": 100}],
-    "quotes": ["warn","double"],
+    "quotes": ["warn", "double"],
     "const-name-snakecase": "warn",
     "contract-name-camelcase": "warn",
     "event-name-camelcase": "warn",

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,8 +1,11 @@
 {
   "name": "bridge",
   "version": "0.1.0",
+  "engines": {
+    "node": "^16.0.0"
+  },
   "scripts": {
-    "init": "hardhat typechain",
+    "typechain": "hardhat typechain",
     "test": "hardhat test --show-stack-traces",
     "test-parallel": "hardhat test --parallel --show-stack-traces",
     "clean": "mkdir -p typechain-types && rm -rf typechain-types && hardhat clean && mkdir -p bindings && rm -rf bindings && mkdir -p artifacts && rm -rf artifacts ",

--- a/bridge/scripts/lib/deploymentUtils.ts
+++ b/bridge/scripts/lib/deploymentUtils.ts
@@ -34,7 +34,7 @@ export async function deployStatic(fullyQualifiedName: string) {
 
   let hasConArgs = await hasConstructorArgs(fullyQualifiedName);
   let constructorArgs = hasConArgs
-    ? (await getDeploymentConstructorArgs(fullyQualifiedName))
+    ? await getDeploymentConstructorArgs(fullyQualifiedName)
     : [];
   return await run("deployMetamorphic", {
     contractName: extractName(fullyQualifiedName),

--- a/bridge/scripts/lib/madnetFactoryTasks.ts
+++ b/bridge/scripts/lib/madnetFactoryTasks.ts
@@ -64,29 +64,30 @@ task("getBytes32Salt", "gets the bytes32 version of salt from contract")
 task(
   "deployFactory",
   "Deploys an instance of a factory contract specified by its name"
-)
-  .setAction(async (taskArgs, hre) => {
-    const factoryBase = await hre.ethers.getContractFactory(MADNET_FACTORY);
-    const accounts = await getAccounts(hre);
-    let txCount = await hre.ethers.provider.getTransactionCount(accounts[0]);
-    //calculate the factory address for the constructor arg
-    let futureFactoryAddress = hre.ethers.utils.getContractAddress({
-      from: accounts[0],
-      nonce: txCount,
-    });
-    let deployTX = factoryBase.getDeployTransaction(futureFactoryAddress);
-    let gasCost = await hre.ethers.provider.estimateGas(deployTX);
-    //deploys the factory
-    let factory = await factoryBase.deploy(futureFactoryAddress);
-    await factory.deployTransaction.wait()
-    //record the data in a json file to be used in other tasks
-    let factoryData: FactoryData = {
-      address: factory.address,
-      gas: gasCost.toNumber(),
-    };
-    await updateDefaultFactoryData(factoryData);
-    await showState(`Deployed: ${MADNET_FACTORY}, at address: ${factory.address}`)
-    return factory.address;
+).setAction(async (taskArgs, hre) => {
+  const factoryBase = await hre.ethers.getContractFactory(MADNET_FACTORY);
+  const accounts = await getAccounts(hre);
+  let txCount = await hre.ethers.provider.getTransactionCount(accounts[0]);
+  //calculate the factory address for the constructor arg
+  let futureFactoryAddress = hre.ethers.utils.getContractAddress({
+    from: accounts[0],
+    nonce: txCount,
+  });
+  let deployTX = factoryBase.getDeployTransaction(futureFactoryAddress);
+  let gasCost = await hre.ethers.provider.estimateGas(deployTX);
+  //deploys the factory
+  let factory = await factoryBase.deploy(futureFactoryAddress);
+  await factory.deployTransaction.wait();
+  //record the data in a json file to be used in other tasks
+  let factoryData: FactoryData = {
+    address: factory.address,
+    gas: gasCost.toNumber(),
+  };
+  await updateDefaultFactoryData(factoryData);
+  await showState(
+    `Deployed: ${MADNET_FACTORY}, at address: ${factory.address}`
+  );
+  return factory.address;
 });
 
 task(

--- a/bridge/test/ethdkg/phases/03-dispute-share-distribution.test.ts
+++ b/bridge/test/ethdkg/phases/03-dispute-share-distribution.test.ts
@@ -120,7 +120,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     // submit MPK
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     await submitMasterPublicKey(ethdkg, validators4, expectedNonce);
 
     await assertETHDKGPhase(ethdkg, Phase.GPKJSubmission);
@@ -286,7 +286,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     //await endCurrentPhase(ethdkg)
   });
 
@@ -305,7 +305,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
 
     // try accusing the 1st validator of bad shares using incorrect encrypted shares and commitments
     await expect(
@@ -338,7 +338,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
 
     // try accusing the 1st validator of bad shares using valid encrypted shares and commitments
     await ethdkg
@@ -403,7 +403,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
 
     // try accusing the 4th validator of bad shares using valid encrypted shares and commitments
     await ethdkg
@@ -474,7 +474,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
 
     // try accusing the 1st validator of bad shares using valid encrypted shares and commitments
     await ethdkg
@@ -503,7 +503,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     // try moving into the next phase - KeyShareSubmission
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
     await endCurrentPhase(ethdkg);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     await assertETHDKGPhase(ethdkg, Phase.DisputeShareDistribution);
 
     await expect(
@@ -538,7 +538,7 @@ describe("ETHDKG: Dispute bad shares", () => {
 
     await assertETHDKGPhase(ethdkg, Phase.ShareDistribution);
     await endCurrentPhase(ethdkg);
-    //await mineBlocks((await ethdkg.getConfirmationLength()).toNumber())
+    //await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt())
     await assertETHDKGPhase(ethdkg, Phase.ShareDistribution);
 
     // accuse the 1st validator of bad shares using valid encrypted shares and commitments
@@ -599,7 +599,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     // try moving into the next phase - KeyShareSubmission
     await assertETHDKGPhase(ethdkg, Phase.ShareDistribution);
     await endCurrentPhase(ethdkg);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     await assertETHDKGPhase(ethdkg, Phase.ShareDistribution);
 
     await expect(
@@ -640,7 +640,7 @@ describe("ETHDKG: Dispute bad shares", () => {
     );
 
     await endCurrentAccusationPhase(ethdkg);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     await assertETHDKGPhase(ethdkg, Phase.ShareDistribution);
 
     await expect(

--- a/bridge/test/ethdkg/phases/07-dispute-gpkj-submission.test.ts
+++ b/bridge/test/ethdkg/phases/07-dispute-gpkj-submission.test.ts
@@ -375,7 +375,7 @@ describe("ETHDKG: Dispute GPKj", () => {
     );
 
     // submit MPK
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
     await submitMasterPublicKey(ethdkg, validators4, expectedNonce);
 
     await assertETHDKGPhase(ethdkg, Phase.GPKJSubmission);
@@ -533,7 +533,7 @@ describe("ETHDKG: Dispute GPKj", () => {
 
     //await endCurrentPhase(ethdkg)
     await assertETHDKGPhase(ethdkg, Phase.DisputeGPKJSubmission);
-    await mineBlocks((await ethdkg.getConfirmationLength()).toNumber());
+    await mineBlocks((await ethdkg.getConfirmationLength()).toBigInt());
 
     // length based tests
 

--- a/bridge/test/setup.ts
+++ b/bridge/test/setup.ts
@@ -61,12 +61,11 @@ export function shuffle(a: ValidatorRawData[]) {
   return a;
 }
 
-export const mineBlocks = async (nBlocks: number) => {
-  while (nBlocks > 0) {
-    nBlocks--;
-    await network.provider.request({
-      method: "evm_mine",
-    });
+export const mineBlocks = async (nBlocks: bigint) => {
+  if (nBlocks > BigInt(0)) {
+    await network.provider.send("hardhat_mine", [
+      ethers.utils.hexValue(nBlocks),
+    ]);
   }
 };
 
@@ -377,10 +376,10 @@ export const getFixture = async (
   // finish workaround, putting the blockgas limit to the previous value 30_000_000
   await network.provider.send("evm_setBlockGasLimit", ["0x1C9C380"]);
 
-  let blockNumber = await ethers.provider.getBlockNumber();
-  let phaseLength = await ethdkg.getPhaseLength();
-  if (phaseLength.toNumber() >= blockNumber) {
-    await mineBlocks(phaseLength.toNumber());
+  let blockNumber = BigInt(await ethers.provider.getBlockNumber());
+  let phaseLength = (await ethdkg.getPhaseLength()).toBigInt();
+  if (phaseLength >= blockNumber) {
+    await mineBlocks(phaseLength);
   }
 
   return {

--- a/bridge/test/validatorPool/business-logic/collect-profits.test.ts
+++ b/bridge/test/validatorPool/business-logic/collect-profits.test.ts
@@ -35,14 +35,13 @@ describe("ValidatorPool: Collecting logic", async function () {
       validators,
       stakingTokenIds,
     ]);
+    let eths = ethers.utils.parseEther("4.0").toBigInt();
     let expectedState = await getCurrentState(fixture, validators);
-    //Simulate 4 ETH from admin earned by pool after validators registration
-    expectedState.Admin.ETH -= 4;
     await fixture.validatorNFT.connect(adminSigner).depositEth(42, {
-      value: ethers.utils.parseEther("4.0"),
+      value: eths,
     });
     //Expect ValidatorNFT balance to increment by earnings
-    expectedState.ValidatorNFT.ETH += 4;
+    expectedState.ValidatorNFT.ETH += eths;
     // Complete ETHDKG Round
     await showState("After deposit:", expectedState);
     await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
@@ -54,8 +53,7 @@ describe("ValidatorPool: Collecting logic", async function () {
       .connect(await getValidatorEthAccount(validatorsSnapshots[0]))
       .collectProfits();
     // Expect that a fraction of the earnings (1/4 validators) to be transfer from ValidatorNFT to collecting validator
-    expectedState.ValidatorNFT.ETH -= 1;
-    expectedState.validators[0].ETH += 1;
+    expectedState.ValidatorNFT.ETH -= eths / BigInt(4);
     let currentState = await getCurrentState(fixture, validators);
     await showState("Expected state after collect profit", expectedState);
     await showState("Current state after collect profit", currentState);
@@ -69,22 +67,19 @@ describe("ValidatorPool: Collecting logic", async function () {
     ]);
     let expectedState = await getCurrentState(fixture, validators);
     let maxNumValidators = validatorsSnapshots.length;
-    let eths = 4;
-    let mads = 4;
+    let eths = ethers.utils.parseEther(`4`).toBigInt();
+    let mads = ethers.utils.parseEther(`4`).toBigInt();
     await fixture.validatorNFT.connect(adminSigner).depositEth(42, {
-      value: ethers.utils.parseEther(`${eths}`),
+      value: eths,
     });
     await fixture.madToken
       .connect(adminSigner)
-      .approve(fixture.validatorNFT.address, ethers.utils.parseEther("4"));
-    await fixture.validatorNFT
-      .connect(adminSigner)
-      .depositToken(42, ethers.utils.parseEther(`${mads}`));
+      .approve(fixture.validatorNFT.address, mads);
+    await fixture.validatorNFT.connect(adminSigner).depositToken(42, mads);
     //Expect ValidatorNFT balance to increment by earnings
-    expectedState.ValidatorNFT.ETH += 4;
-    expectedState.ValidatorNFT.MAD += 4;
-    expectedState.Admin.MAD -= 4;
-    expectedState.Admin.ETH -= 4;
+    expectedState.ValidatorNFT.ETH += eths;
+    expectedState.ValidatorNFT.MAD += mads;
+    expectedState.Admin.MAD -= mads;
     // Complete ETHDKG Round
     let currentState = await getCurrentState(fixture, validators);
     await showState("Expected state after deposit", expectedState);
@@ -101,10 +96,9 @@ describe("ValidatorPool: Collecting logic", async function () {
         .collectProfits();
     }
     validators.map((_, index) => {
-      expectedState.ValidatorNFT.ETH -= eths / maxNumValidators;
-      expectedState.validators[index].ETH += eths / maxNumValidators;
-      expectedState.ValidatorNFT.MAD -= mads / maxNumValidators;
-      expectedState.validators[index].MAD += mads / maxNumValidators;
+      expectedState.ValidatorNFT.ETH -= eths / BigInt(maxNumValidators);
+      expectedState.ValidatorNFT.MAD -= mads / BigInt(maxNumValidators);
+      expectedState.validators[index].MAD += mads / BigInt(maxNumValidators);
       expectedState.validators[index].Reg = true;
       expectedState.validators[index].Acc = true;
     });

--- a/bridge/test/validatorPool/business-logic/consensus-dependent-functions.test.ts
+++ b/bridge/test/validatorPool/business-logic/consensus-dependent-functions.test.ts
@@ -1,23 +1,22 @@
 import { BigNumber, Signer } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, network } from "hardhat";
 import { expect } from "../../chai-setup";
-import { completeETHDKGRound } from "../../ethdkg/setup";
+import {
+  assertEventValidatorSetCompleted,
+  completeETHDKGRound,
+} from "../../ethdkg/setup";
 import {
   factoryCallAny,
   Fixture,
   getFixture,
   getValidatorEthAccount,
 } from "../../setup";
-import { validatorsSnapshots } from "../../snapshots/assets/4-validators-snapshots-1";
-import { validatorsSnapshots as validatorsSnapshots2 } from "../../snapshots/assets/4-validators-snapshots-2";
 import {
-  claimPosition,
-  commitSnapshots,
-  createValidators,
-  getCurrentState,
-  showState,
-  stakeValidators,
-} from "../setup";
+  validatorsSnapshots,
+  validSnapshot1024,
+} from "../../snapshots/assets/4-validators-snapshots-1";
+import { validatorsSnapshots as validatorsSnapshots2 } from "../../snapshots/assets/4-validators-snapshots-2";
+import { createValidators, stakeValidators } from "../setup";
 
 describe("ValidatorPool: Consensus dependent logic ", async () => {
   let fixture: Fixture;
@@ -26,7 +25,7 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
   let stakingTokenIds: BigNumber[];
 
   beforeEach(async function () {
-    fixture = await getFixture(false, true, true);
+    fixture = await getFixture(false, true, false);
     const [admin, , ,] = fixture.namedSigners;
     adminSigner = await getValidatorEthAccount(admin.address);
     validators = await createValidators(fixture, validatorsSnapshots);
@@ -39,9 +38,15 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
       stakingTokenIds,
     ]);
     await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    await completeETHDKGRound(validatorsSnapshots, {
+      ethdkg: fixture.ethdkg,
+      validatorPool: fixture.validatorPool,
+    });
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
   });
 
-  it("Should not allow pausing “consensus” before 1.5 without snapshots.", async function () {
+  it("Should not allow pausing “consensus” before 1.5 without snapshots", async function () {
     await expect(
       factoryCallAny(
         fixture,
@@ -52,67 +57,140 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
     ).to.be.revertedWith("ValidatorPool: Condition not met to stop consensus!");
   });
 
-  it("Pause consensus after 1.5 days without snapshot.", async function () {
-    // Simulating in mock with MAX_INTERVAL_WITHOUT_SNAPSHOTS = 0 instead of 8192
-    fixture = await getFixture(true, true, true);
-    await factoryCallAny(
+  it("Pause consensus after 1.5 days without snapshot", async function () {
+    // set consensus running
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    await completeETHDKGRound(validatorsSnapshots, {
+      ethdkg: fixture.ethdkg,
+      validatorPool: fixture.validatorPool,
+    });
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
+    // simulate a period without snapshots
+    await network.provider.send("hardhat_mine", [
+      ethers.utils.hexValue(
+        (
+          await fixture.validatorPool.MAX_INTERVAL_WITHOUT_SNAPSHOTS()
+        ).toBigInt() + BigInt(1)
+      ),
+    ]);
+    let tx = await factoryCallAny(
       fixture,
       "validatorPool",
       "pauseConsensusOnArbitraryHeight",
       [1]
     );
-  });
-
-  it("After 1.5 days without snapshots, replace validators and run ETHDKG to completion.", async function () {
-    // Simulating in mock with MAX_INTERVAL_WITHOUT_SNAPSHOTS = 0 instead of 8192
-    fixture = await getFixture(true, true, true);
-    validators = await createValidators(fixture, validatorsSnapshots);
-    stakingTokenIds = await stakeValidators(fixture, validators);
-    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
-      validators,
-      stakingTokenIds,
-    ]);
-    // Complete ETHDKG Round
-    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
-    await factoryCallAny(fixture, "validatorPool", "unregisterValidators", [
-      validators,
-    ]);
-    await completeETHDKGRound(validatorsSnapshots, {
-      ethdkg: fixture.ethdkg,
-      validatorPool: fixture.validatorPool,
-    });
-  });
-
-  it("Complete ETHDKG and check if the necessary state was set properly", async function () {
-    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
-      validators,
-      stakingTokenIds,
-    ]);
-    // Complete ETHDKG Round
-    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
-    await completeETHDKGRound(validatorsSnapshots, {
-      ethdkg: fixture.ethdkg,
-      validatorPool: fixture.validatorPool,
-    });
-    expect(await fixture.validatorPool.isMaintenanceScheduled()).to.be.false;
-    //Consensus Running should be true
-    await expect(
-      factoryCallAny(fixture, "validatorPool", "registerValidators", [
-        validators,
-        stakingTokenIds,
-      ])
-    ).to.be.revertedWith(
-      "ValidatorPool: Error Madnet Consensus should be halted!"
+    let receipt = await ethers.provider.getTransaction(tx.transactionHash);
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    // special event to halt consensus in the side chain
+    await assertEventValidatorSetCompleted(
+      receipt,
+      0,
+      1,
+      0,
+      0,
+      1,
+      [0, 0, 0, 0]
     );
   });
 
-  it("Should not allow start ETHDKG if consensus is true or and ETHDKG round is running.", async function () {
+  it("After 1.5 days without snapshots, replace validators and run ETHDKG to completion", async function () {
+    // set consensus running
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    await completeETHDKGRound(validatorsSnapshots, {
+      ethdkg: fixture.ethdkg,
+      validatorPool: fixture.validatorPool,
+    });
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
+    // simulate a period without snapshots
+    await network.provider.send("hardhat_mine", [
+      ethers.utils.hexValue(
+        (
+          await fixture.validatorPool.MAX_INTERVAL_WITHOUT_SNAPSHOTS()
+        ).toBigInt() + BigInt(1)
+      ),
+    ]);
+    let arbitraryMadnetHeight = 42;
+    let tx = await factoryCallAny(
+      fixture,
+      "validatorPool",
+      "pauseConsensusOnArbitraryHeight",
+      [arbitraryMadnetHeight]
+    );
+    let transaction = await ethers.provider.getTransaction(tx.transactionHash);
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    // special event to halt consensus in the side chain
+    await assertEventValidatorSetCompleted(
+      transaction,
+      0,
+      1,
+      0,
+      0,
+      arbitraryMadnetHeight,
+      [0, 0, 0, 0]
+    );
+    await factoryCallAny(fixture, "validatorPool", "unregisterValidators", [
+      validators,
+    ]);
+
+    let newValidators = await createValidators(fixture, validatorsSnapshots2);
+    let newStakingTokenIds = await stakeValidators(fixture, validators);
+
+    // set consensus running
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      newValidators,
+      newStakingTokenIds,
+    ]);
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    await completeETHDKGRound(
+      validatorsSnapshots2,
+      {
+        ethdkg: fixture.ethdkg,
+        validatorPool: fixture.validatorPool,
+      },
+      undefined,
+      arbitraryMadnetHeight
+    );
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
+  });
+
+  it("Complete ETHDKG and check if the necessary state was set properly", async function () {
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
     await factoryCallAny(fixture, "validatorPool", "registerValidators", [
       validators,
       stakingTokenIds,
     ]);
     // Complete ETHDKG Round
     await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
+    expect(await fixture.validatorPool.isMaintenanceScheduled()).to.be.false;
+    await completeETHDKGRound(validatorsSnapshots, {
+      ethdkg: fixture.ethdkg,
+      validatorPool: fixture.validatorPool,
+    });
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
+  });
+
+  it("Should not allow start ETHDKG if consensus is true or and ETHDKG round is running", async function () {
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    // Complete ETHDKG Round
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
+    await expect(
+      factoryCallAny(fixture, "validatorPool", "initializeETHDKG")
+    ).to.be.revertedWith("ValidatorPool: There's an ETHDKG round running!");
     await completeETHDKGRound(validatorsSnapshots, {
       ethdkg: fixture.ethdkg,
       validatorPool: fixture.validatorPool,
@@ -124,102 +202,65 @@ describe("ValidatorPool: Consensus dependent logic ", async () => {
     );
   });
 
-  it("Test running ETHDKG with the arbitrary height sent as input, see if the value (the arbitrary height) is correctly added to the ethdkg completion event.", async function () {
-    const height = 4;
-    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
-    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
-    await expect(fixture.ethdkg.setCustomMadnetHeight(height))
-      .to.emit(fixture.ethdkg, "ValidatorSetCompleted")
-      .withArgs(0, 0, 0, 0, height, 0, 0, 0, 0);
-  });
-
-  it("Check if consensus is halted after maintenance is scheduled and snapshot is done.", async function () {
-    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
-      validators,
-      stakingTokenIds,
-    ]);
-    await showState(
-      "after registering",
-      await getCurrentState(fixture, validators)
-    );
-    let expectedState = await getCurrentState(fixture, validators);
-    // Complete ETHDKG Round
-    await factoryCallAny(fixture, "ethdkg", "initializeETHDKG");
-    await showState(
-      "after initializing",
-      await getCurrentState(fixture, validators)
-    );
-    await completeETHDKGRound(validatorsSnapshots, {
-      ethdkg: fixture.ethdkg,
-      validatorPool: fixture.validatorPool,
-    });
-    await factoryCallAny(fixture, "validatorPool", "scheduleMaintenance");
-    await commitSnapshots(fixture, 1);
-    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
-  });
-
   it("Register validators, run ethdkg, schedule maintenance, do a snapshot, replace some validators, and rerun ethdkg", async function () {
+    let fixture = await getFixture();
+    validators = await createValidators(fixture, validatorsSnapshots);
+    stakingTokenIds = await stakeValidators(fixture, validators);
     await factoryCallAny(fixture, "validatorPool", "registerValidators", [
       validators,
       stakingTokenIds,
     ]);
-    await showState(
-      "after registering",
-      await getCurrentState(fixture, validators)
-    );
-    let expectedState = await getCurrentState(fixture, validators);
-    // // Complete ETHDKG Round
-    await factoryCallAny(fixture, "ethdkg", "initializeETHDKG");
-    await showState(
-      "After initializing",
-      await getCurrentState(fixture, validators)
-    );
+    // Complete ETHDKG Round
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
     await completeETHDKGRound(validatorsSnapshots, {
       ethdkg: fixture.ethdkg,
       validatorPool: fixture.validatorPool,
     });
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.true;
+    expect(await fixture.validatorPool.isMaintenanceScheduled()).to.be.false;
     await factoryCallAny(fixture, "validatorPool", "scheduleMaintenance");
-    await commitSnapshots(fixture, 1);
-    expect(await fixture.validatorPool.isConsensusRunning()).to.be.false;
-    await showState(
-      "After maintenance",
-      await getCurrentState(fixture, validators)
+    expect(await fixture.validatorPool.isMaintenanceScheduled()).to.be.true;
+    await fixture.snapshots
+      .connect(await getValidatorEthAccount(validatorsSnapshots[0]))
+      .snapshot(validSnapshot1024.GroupSignature, validSnapshot1024.BClaims);
+    expect(await fixture.validatorPool.isConsensusRunning()).to.be.equal(
+      false,
+      "Consensus should be halted!"
     );
-    await factoryCallAny(fixture, "validatorPool", "unregisterValidators", [
-      validators,
-    ]);
-    await showState(
-      "After unregistering",
-      await getCurrentState(fixture, validators)
-    );
-    await commitSnapshots(fixture, 4);
-    for (const validator of validatorsSnapshots) {
-      await claimPosition(fixture, validator);
-    }
-    // Re mint positions
+
+    await factoryCallAny(fixture, "validatorPool", "unregisterAllValidators");
     let newValidators = await createValidators(fixture, validatorsSnapshots2);
-    let newStakeNFTIDs = await stakeValidators(fixture, newValidators);
+    let newStakingTokenIds = await stakeValidators(fixture, newValidators);
     await factoryCallAny(fixture, "validatorPool", "registerValidators", [
       newValidators,
-      newStakeNFTIDs,
+      newStakingTokenIds,
     ]);
-    await showState(
-      "After registering",
-      await getCurrentState(fixture, validators)
-    );
-    let currentState = await getCurrentState(fixture, validators);
-    await factoryCallAny(fixture, "ethdkg", "initializeETHDKG");
-    await showState(
-      "After initializing",
-      await getCurrentState(fixture, validators)
-    );
+    // Complete ETHDKG Round
+    await factoryCallAny(fixture, "validatorPool", "initializeETHDKG");
     await completeETHDKGRound(
       validatorsSnapshots2,
       {
         ethdkg: fixture.ethdkg,
         validatorPool: fixture.validatorPool,
       },
-      5
+      1,
+      1024,
+      (
+        await fixture.snapshots.getCommittedHeightFromLatestSnapshot()
+      ).toNumber()
     );
+    expect(await fixture.validatorPool.isMaintenanceScheduled()).to.be.equal(
+      false,
+      "No maintenance should be scheduled!"
+    );
+  });
+
+  it("Normal users should not be able to send ethereum to the contract", async function () {
+    await expect(
+      adminSigner.sendTransaction({
+        to: fixture.validatorPool.address,
+        value: 1000,
+      })
+    ).to.be.revertedWith("Only NFT contracts allowed to send ethereum!");
   });
 });

--- a/bridge/test/validatorPool/business-logic/slashing.test.ts
+++ b/bridge/test/validatorPool/business-logic/slashing.test.ts
@@ -12,6 +12,7 @@ import {
   commitSnapshots,
   createValidators,
   getCurrentState,
+  getStakeNFTFromMinorSlashEvent,
   showState,
   stakeValidators,
 } from "../setup";
@@ -19,24 +20,24 @@ import {
 describe("ValidatorPool: Slashing logic", async () => {
   let fixture: Fixture;
   let adminSigner: Signer;
-  let maxNumValidators = 4; //default number
-  let stakeAmount = 20000;
   let validators: string[];
   let stakingTokenIds: BigNumber[];
+  let stakeAmount: bigint;
 
-  beforeEach(async function () {
+  beforeEach(async () => {
     fixture = await getFixture(false, true, true);
     const [admin, , ,] = fixture.namedSigners;
     adminSigner = await getValidatorEthAccount(admin.address);
     validators = await createValidators(fixture, validatorsSnapshots);
     stakingTokenIds = await stakeValidators(fixture, validators);
+    stakeAmount = (await fixture.validatorPool.getStakeAmount()).toBigInt();
   });
 
   it("Minor slash a validator", async function () {
-    let reward = 1;
+    let reward = ethers.utils.parseEther("1").toBigInt();
     //Set reward to 1 MadToken
     await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
-      ethers.utils.parseEther("" + reward),
+      reward,
     ]);
     // Obtain ETHDKG Mock
     const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
@@ -57,14 +58,14 @@ describe("ValidatorPool: Slashing logic", async () => {
     );
     let currentState = await getCurrentState(fixture, validators);
     // Expect infringer validator position to be unregister
-    expectedState.ValidatorPool.ValNFT -= 1;
-    expectedState.ValidatorPool.StakeNFT += 1;
+    expectedState.ValidatorPool.ValNFT--;
+    expectedState.ValidatorPool.StakeNFT++;
 
     // Expect infringer to loose the validator position
     expectedState.StakeNFT.MAD += stakeAmount;
     expectedState.ValidatorNFT.MAD -= stakeAmount;
     // Expect infringer to loose reward on his staking position and be transferred to accusator
-    expectedState.StakeNFT.MAD -= 1;
+    expectedState.StakeNFT.MAD -= reward;
     expectedState.validators[1].MAD += reward;
     expectedState.validators[0].Acc = true;
     expectedState.validators[0].ExQ = true;
@@ -74,11 +75,288 @@ describe("ValidatorPool: Slashing logic", async () => {
     expect(currentState).to.be.deep.equal(expectedState);
   });
 
-  it("Major slash a validator", async function () {
-    let reward = 3;
+  it("Minor slash a validator then he leaves the pool", async function () {
+    let reward = ethers.utils.parseEther("1").toBigInt();
     //Set reward to 1 MadToken
     await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
-      ethers.utils.parseEther("" + reward),
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    await showState(
+      "After registering",
+      await getCurrentState(fixture, validators)
+    );
+    let tx = await ethdkg.minorSlash(validators[0], validators[1]);
+    let newStakeNFT = await getStakeNFTFromMinorSlashEvent(tx);
+    expect(newStakeNFT).to.be.gt(
+      BigInt(0),
+      "New StakeNFT position was not created properly!"
+    );
+    await showState(
+      "After minor slashing",
+      await getCurrentState(fixture, validators)
+    );
+    let currentState = await getCurrentState(fixture, validators);
+    // Expect infringer validator position to be unregister
+    expectedState.ValidatorPool.ValNFT--;
+    expectedState.ValidatorPool.StakeNFT++;
+
+    // Expect infringer to loose the validator position
+    expectedState.StakeNFT.MAD += stakeAmount;
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+    // Expect infringer to loose reward on his staking position and be transferred to accusator
+    expectedState.StakeNFT.MAD -= reward;
+    expectedState.validators[1].MAD += reward;
+    expectedState.validators[0].Acc = true;
+    expectedState.validators[0].ExQ = true;
+    expectedState.validators[0].Reg = false;
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed assert after minor slash"
+    );
+
+    await commitSnapshots(fixture, 4);
+
+    let claimTx = (await fixture.validatorPool
+      .connect(await getValidatorEthAccount(validatorsSnapshots[0]))
+      .claimExitingNFTPosition()) as ContractTransaction;
+    let receipt = await ethers.provider.getTransactionReceipt(claimTx.hash);
+    let exitingNFT = BigNumber.from(receipt.logs[0].topics[3]);
+    let blockNumber = receipt.blockNumber;
+
+    expect(exitingNFT.toBigInt()).to.be.equal(
+      newStakeNFT,
+      "Failed claiming NFT position!"
+    );
+
+    expect(
+      (await fixture.stakeNFT.ownerOf(newStakeNFT)).toLowerCase()
+    ).to.be.equal(validatorsSnapshots[0].address.toLowerCase());
+
+    let position = await fixture.stakeNFT.getPosition(newStakeNFT);
+    expect(position.freeAfter.toBigInt()).to.be.equal(
+      (await fixture.validatorPool.POSITION_LOCK_PERIOD()).toBigInt() +
+        BigInt(blockNumber)
+    );
+  });
+
+  it("Minor slash a validator then major slash it", async function () {
+    let reward = ethers.utils.parseEther("10000").toBigInt();
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    let tx = await ethdkg.minorSlash(validators[0], validators[1]);
+    let newStakeNFT = await getStakeNFTFromMinorSlashEvent(tx);
+    expect(newStakeNFT).to.be.gt(
+      BigInt(0),
+      "New StakeNFT position was not created properly!"
+    );
+    let currentState = await getCurrentState(fixture, validators);
+    // Expect infringer validator position to be unregister
+    expectedState.ValidatorPool.ValNFT--;
+    expectedState.ValidatorPool.StakeNFT++;
+
+    // Expect infringer to loose the validator position
+    expectedState.StakeNFT.MAD += stakeAmount - reward;
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+    // Expect infringer to loose reward on his staking position and be transferred to accusator
+    expectedState.validators[1].MAD += reward;
+    expectedState.validators[0].Acc = true;
+    expectedState.validators[0].ExQ = true;
+    expectedState.validators[0].Reg = false;
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed assert after minor slash"
+    );
+
+    expectedState = await getCurrentState(fixture, validators);
+    await ethdkg.majorSlash(validators[0], validators[2]);
+    currentState = await getCurrentState(fixture, validators);
+    // Expect infringer unregister the validator position
+    expectedState.ValidatorPool.StakeNFT--;
+    // Expect reward to be transferred from ValidatorNFT to disputer
+    expectedState.StakeNFT.MAD -= stakeAmount - reward;
+    // the stakeamount minus the 2 rewards given to the 2 accusators should be redistributed to all
+    // validators
+    expectedState.ValidatorNFT.MAD += stakeAmount - BigInt(2) * reward;
+    expectedState.validators[2].MAD += reward;
+    // Expect infringer to be unregistered, not in exiting queue and not accusable
+    expectedState.validators[0].Reg = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Acc = false;
+
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed checking state after major slashing!"
+    );
+  });
+
+  it("Minor slash a validator then major slash it with funds distribution in the middle", async function () {
+    let reward = ethers.utils.parseEther("10000").toBigInt();
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let eths = 4;
+    let mads = 20;
+    await fixture.validatorNFT.connect(adminSigner).depositEth(42, {
+      value: ethers.utils.parseEther(`${eths}`),
+    });
+    await fixture.madToken
+      .connect(adminSigner)
+      .approve(
+        fixture.validatorNFT.address,
+        ethers.utils.parseEther(`${mads}`)
+      );
+    await fixture.validatorNFT
+      .connect(adminSigner)
+      .depositToken(42, ethers.utils.parseEther(`${mads}`));
+    let expectedState = await getCurrentState(fixture, validators);
+    let tx = await ethdkg.minorSlash(validators[0], validators[1]);
+    let newStakeNFT = await getStakeNFTFromMinorSlashEvent(tx);
+    expect(newStakeNFT).to.be.gt(
+      BigInt(0),
+      "New StakeNFT position was not created properly!"
+    );
+    let currentState = await getCurrentState(fixture, validators);
+    // Expect infringer validator position to be unregister
+    expectedState.ValidatorPool.ValNFT--;
+    expectedState.ValidatorPool.StakeNFT++;
+
+    // Expect infringer to loose the validator position
+    expectedState.StakeNFT.MAD += stakeAmount - reward;
+    expectedState.ValidatorNFT.MAD -=
+      stakeAmount + ethers.utils.parseEther(`${mads / 4}`).toBigInt();
+    expectedState.ValidatorNFT.ETH -= ethers.utils
+      .parseEther(`${eths / 4}`)
+      .toBigInt();
+    // Expect infringer to loose reward on his staking position and be transferred to accusator
+    expectedState.validators[1].MAD +=
+      reward + ethers.utils.parseEther("5").toBigInt(); // result from distribution
+    expectedState.validators[0].Acc = true;
+    expectedState.validators[0].ExQ = true;
+    expectedState.validators[0].Reg = false;
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed assert after minor slash"
+    );
+    // the validatorPool shouldn't have any balance
+    expect(
+      (
+        await ethers.provider.getBalance(fixture.validatorPool.address)
+      ).toBigInt()
+    ).to.be.equal(BigInt(0), "ValidatorPool shouldn't have any balance");
+
+    // minting 1 stakeNFt so all the profit funds are not moved from the stakenft contract at slashing
+    // time
+    let newStakeAmount = (stakeAmount - reward) * BigInt(3);
+    await fixture.madToken
+      .connect(adminSigner)
+      .approve(fixture.stakeNFT.address, newStakeAmount);
+    await fixture.stakeNFT.connect(adminSigner).mint(newStakeAmount);
+
+    // Deposit now in the stakeNFT contract
+    await fixture.stakeNFT.connect(adminSigner).depositEth(42, {
+      value: ethers.utils.parseEther(`${eths}`),
+    });
+    await fixture.madToken
+      .connect(adminSigner)
+      .approve(fixture.stakeNFT.address, ethers.utils.parseEther(`${mads}`));
+    await fixture.stakeNFT
+      .connect(adminSigner)
+      .depositToken(42, ethers.utils.parseEther(`${mads}`));
+
+    expectedState = await getCurrentState(fixture, validators);
+    await ethdkg.majorSlash(validators[0], validators[2]);
+    currentState = await getCurrentState(fixture, validators);
+    // Expect infringer unregister the validator position
+    expectedState.ValidatorPool.StakeNFT--;
+    expectedState.StakeNFT.ETH -= ethers.utils
+      .parseEther(`${eths / 4}`)
+      .toBigInt();
+    // Expect reward to be transferred from ValidatorNFT to disputer
+    expectedState.StakeNFT.MAD -=
+      stakeAmount - reward + ethers.utils.parseEther(`${mads / 4}`).toBigInt();
+    // the stakeamount minus the 2 rewards given to the 2 accusators should be redistributed to all
+    // validators
+    expectedState.ValidatorNFT.MAD += stakeAmount - BigInt(2) * reward;
+    expectedState.validators[2].MAD +=
+      reward + ethers.utils.parseEther(`${mads / 4}`).toBigInt();
+    // Expect infringer to be unregistered, not in exiting queue and not accusable
+    expectedState.validators[0].Reg = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Acc = false;
+
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed checking state after major slashing!"
+    );
+
+    expect(
+      (
+        await ethers.provider.getBalance(fixture.validatorPool.address)
+      ).toBigInt()
+    ).to.be.equal(
+      BigInt(0),
+      "ValidatorPool shouldn't have any balance after major slash"
+    );
+
+    await ethdkg.setConsensusRunning();
+    expectedState = await getCurrentState(fixture, validators);
+    let collectedAmount =
+      (stakeAmount - BigInt(2) * reward) /
+        BigInt(validatorsSnapshots.length - 1) +
+      ethers.utils.parseEther(`${mads / 4}`).toBigInt();
+    for (let index = 1; index < validatorsSnapshots.length; index++) {
+      await fixture.validatorPool
+        .connect(await getValidatorEthAccount(validatorsSnapshots[index]))
+        .collectProfits();
+      expectedState.validators[index].MAD += collectedAmount;
+      expectedState.ValidatorNFT.ETH -= ethers.utils
+        .parseEther(`${eths / 4}`)
+        .toBigInt();
+      expectedState.ValidatorNFT.MAD -= collectedAmount;
+    }
+    currentState = await getCurrentState(fixture, validators);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed in the assertion after collect Profits"
+    );
+  });
+
+  it("Major slash a validator then validators collect profit", async function () {
+    let reward = ethers.utils.parseEther("5000").toBigInt();
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
     ]);
     // Obtain ETHDKG Mock
     const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
@@ -94,7 +372,7 @@ describe("ValidatorPool: Slashing logic", async () => {
       await getCurrentState(fixture, validators)
     );
     // Expect infringer unregister the validator position
-    expectedState.ValidatorPool.ValNFT -= 1;
+    expectedState.ValidatorPool.ValNFT--;
     // Expect reward to be transferred from ValidatorNFT to disputer
     expectedState.ValidatorNFT.MAD -= reward;
     expectedState.validators[1].MAD += reward;
@@ -105,31 +383,230 @@ describe("ValidatorPool: Slashing logic", async () => {
     let currentState = await getCurrentState(fixture, validators);
     await showState("Expected state", expectedState);
     await showState("Current state", currentState);
-    expect(currentState).to.be.deep.equal(expectedState);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed checking state after major slashing!"
+    );
+
     await ethdkg.setConsensusRunning();
     expectedState = await getCurrentState(fixture, validators);
-    for (let index = 1; index <= 3; index++) {
+    let collectedAmount =
+      (stakeAmount - reward) / BigInt(validatorsSnapshots.length - 1);
+    for (let index = 1; index < validatorsSnapshots.length; index++) {
       await fixture.validatorPool
         .connect(await getValidatorEthAccount(validatorsSnapshots[index]))
         .collectProfits();
-      expectedState.validators[index].MAD +=
-        (stakeAmount - reward) / (maxNumValidators - 1);
+      expectedState.validators[index].MAD += collectedAmount;
+      expectedState.ValidatorNFT.MAD -= collectedAmount;
     }
-    expectedState.ValidatorNFT.MAD -= stakeAmount - reward;
+    currentState = await getCurrentState(fixture, validators);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed in the assertion after collect Profits"
+    );
+  });
+
+  it("Should not allow major slash a validator twice", async function () {
+    let reward = ethers.utils.parseEther("5000").toBigInt();
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    await ethdkg.majorSlash(validators[0], validators[1]);
+    // Expect infringer unregister the validator position
+    expectedState.ValidatorPool.ValNFT--;
+    // Expect reward to be transferred from ValidatorNFT to disputer
+    expectedState.ValidatorNFT.MAD -= reward;
+    expectedState.validators[1].MAD += reward;
+    // Expect infringer to be unregistered, not in exiting queue and not accusable
+    expectedState.validators[0].Reg = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Acc = false;
+    let currentState = await getCurrentState(fixture, validators);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed checking state after major slashing!"
+    );
+    await expect(
+      ethdkg.majorSlash(validators[0], validators[1])
+    ).to.be.revertedWith(
+      "ValidatorPool: DishonestValidator should be a validator or be in the exiting line!"
+    );
+  });
+
+  it("Should not allow major/minor slash a person that it's not a validator", async function () {
+    let reward = ethers.utils.parseEther("5000").toBigInt();
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    await expect(
+      ethdkg.majorSlash(await adminSigner.getAddress(), validators[1])
+    ).to.be.revertedWith(
+      "ValidatorPool: DishonestValidator should be a validator or be in the exiting line!"
+    );
+
+    await expect(
+      ethdkg.minorSlash(await adminSigner.getAddress(), validators[1])
+    ).to.be.revertedWith(
+      "ValidatorPool: DishonestValidator should be a validator or be in the exiting line!"
+    );
+  });
+
+  it("Major slash a validator with disputer reward greater than stake Amount", async function () {
+    let reward = (await fixture.validatorPool.getStakeAmount()).toBigInt();
+    reward *= BigInt(2);
+    //Set reward to 1 MadToken
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    await ethdkg.majorSlash(validators[0], validators[1]);
+    await showState(
+      "After major slashing",
+      await getCurrentState(fixture, validators)
+    );
+    // Expect infringer unregister the validator position
+    expectedState.ValidatorPool.ValNFT--;
+    // Expect reward to be transferred from ValidatorNFT to disputer
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+    expectedState.validators[1].MAD += stakeAmount;
+    // Expect infringer to be unregistered, not in exiting queue and not accusable
+    expectedState.validators[0].Reg = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Acc = false;
+    let currentState = await getCurrentState(fixture, validators);
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed checking state after major slashing!"
+    );
+
+    await ethdkg.setConsensusRunning();
+    expectedState = await getCurrentState(fixture, validators);
+    let collectedAmount = BigInt(0);
+    for (let index = 1; index < validatorsSnapshots.length; index++) {
+      await fixture.validatorPool
+        .connect(await getValidatorEthAccount(validatorsSnapshots[index]))
+        .collectProfits();
+      expectedState.validators[index].MAD += collectedAmount;
+      expectedState.ValidatorNFT.MAD -= collectedAmount;
+    }
     currentState = await getCurrentState(fixture, validators);
     await showState("Expected state", expectedState);
     await showState("Current state", currentState);
-    expect(currentState).to.be.deep.equal(expectedState);
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      "Failed in the assertion after collect Profits"
+    );
   });
 
   it("Minor slash a validator until he has no more funds", async function () {
     //Set reward to 1 MadToken
-    let reward = 1;
+    let reward = (await fixture.validatorPool.getStakeAmount())
+      .div(4)
+      .add(1)
+      .toBigInt();
     // Set infringer and disputer validators
     let infringer = validators[0];
     let disputer = validators[1];
     await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
-      ethers.utils.parseEther("" + reward),
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    await showState("After registering", expectedState);
+
+    await ethdkg.minorSlash(infringer, disputer);
+    let currentState = await getCurrentState(fixture, validators);
+    await showState("After minor slashing", currentState);
+
+    // Expect infringer validator position to be unregister
+    expectedState.ValidatorPool.ValNFT--;
+    expectedState.ValidatorPool.StakeNFT++;
+
+    // Expect infringer to loose the validator position
+    expectedState.StakeNFT.MAD += stakeAmount - reward;
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+
+    // Expect infringer to loose reward on his staking position and be transferred to accusator
+    expectedState.validators[1].MAD += reward;
+    expectedState.validators[0].Acc = true;
+    expectedState.validators[0].ExQ = true;
+    expectedState.validators[0].Reg = false;
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(expectedState);
+
+    // burn the guy more 2 times
+    for (let i = 0; i < 2; i++) {
+      let expectedState = await getCurrentState(fixture, validators);
+      await ethdkg.minorSlash(infringer, disputer);
+      let currentState = await getCurrentState(fixture, validators);
+      expectedState.StakeNFT.MAD -= reward;
+      expectedState.validators[1].MAD += reward;
+      expectedState.validators[0].Acc = true;
+      expectedState.validators[0].ExQ = true;
+      expectedState.validators[0].Reg = false;
+      expect(currentState).to.be.deep.equal(
+        expectedState,
+        `After minor slashing: ${i}`
+      );
+    }
+    let finalReward = stakeAmount - BigInt(3) * reward;
+    // After last minor slash the guy should have any funds to generate a new stakeNFT position
+    expectedState = await getCurrentState(fixture, validators);
+    await ethdkg.minorSlash(infringer, disputer);
+    currentState = await getCurrentState(fixture, validators);
+    expectedState.StakeNFT.MAD -= finalReward;
+    expectedState.ValidatorPool.StakeNFT--;
+    expectedState.validators[1].MAD += finalReward;
+    expectedState.validators[0].Acc = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Reg = false;
+    expect(currentState).to.be.deep.equal(
+      expectedState,
+      `Failed on final minor slashing`
+    );
+    await expect(ethdkg.minorSlash(infringer, disputer)).to.be.revertedWith(
+      "ValidatorPool: DishonestValidator should be a validator or be in the exiting line!"
+    );
+  });
+
+  it("Minor slash a validator with reward equals to the staking amount", async function () {
+    let reward = (await fixture.validatorPool.getStakeAmount()).toBigInt();
+    // Set reward to be equal to the staked amount (in this case minor will be equal to major slashes)
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
     ]);
     // Obtain ETHDKG Mock
     const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
@@ -143,49 +620,66 @@ describe("ValidatorPool: Slashing logic", async () => {
       "After registering",
       await getCurrentState(fixture, validators)
     );
-    await ethdkg.minorSlash(infringer, disputer);
+    await ethdkg.minorSlash(validators[0], validators[1]);
     await showState(
       "After minor slashing",
       await getCurrentState(fixture, validators)
     );
-    await commitSnapshots(fixture, 4);
-    // Prepare arrays for re-registering
-    validatorsSnapshots.length = 1;
-    stakingTokenIds = [];
-    for (const validator of validatorsSnapshots) {
-      let claimTx = (await fixture.validatorPool
-        .connect(await getValidatorEthAccount(validator))
-        .claimExitingNFTPosition()) as ContractTransaction;
-      await showState(
-        "After claiming",
-        await getCurrentState(fixture, validators)
-      );
-      let receipt = await ethers.provider.getTransactionReceipt(claimTx.hash);
-      //When a token is claimed it gets burned an minted so validator gets a new tokenId so we need to update array for re-registration
-      const tokenId = BigNumber.from(receipt.logs[0].topics[3]);
-      stakingTokenIds.push(tokenId);
-      // Transfer to factory for re-registering
-      await fixture.stakeNFT
-        .connect(await getValidatorEthAccount(validator))
-        .transferFrom(validator.address, fixture.factory.address, tokenId);
-      await showState(
-        "After transferring",
-        await getCurrentState(fixture, validators)
-      );
-      // Approve new tokensIds
-      await factoryCallAny(fixture, "stakeNFT", "approve", [
-        fixture.validatorPool.address,
-        tokenId,
-      ]);
-    }
-    validators.length = 1;
-    await expect(
-      factoryCallAny(fixture, "validatorPool", "registerValidators", [
-        validators,
-        stakingTokenIds,
-      ])
-    ).to.be.revertedWith(
-      "ValidatorStakeNFT: Error, the Stake position doesn't have enough funds!"
+
+    let currentState = await getCurrentState(fixture, validators);
+    // Expect infringer validator position to be unregister
+    expectedState.ValidatorPool.ValNFT--;
+
+    // Expect infringer to loose the validator position and the accusator to have all the funds gained
+    // as reward
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+    expectedState.validators[1].MAD += reward;
+    expectedState.validators[0].Acc = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Reg = false;
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(expectedState);
+  });
+
+  it("Minor slash a validator with reward is greater than the staking amount", async function () {
+    let reward = (await fixture.validatorPool.getStakeAmount()).toBigInt();
+    reward *= BigInt(2);
+    // Set reward to be equal to the staked amount (in this case minor will be equal to major slashes)
+    await factoryCallAny(fixture, "validatorPool", "setDisputerReward", [
+      reward,
+    ]);
+    // Obtain ETHDKG Mock
+    const ETHDKGMockFactory = await ethers.getContractFactory("ETHDKGMock");
+    let ethdkg = ETHDKGMockFactory.attach(fixture.ethdkg.address);
+    await factoryCallAny(fixture, "validatorPool", "registerValidators", [
+      validators,
+      stakingTokenIds,
+    ]);
+    let expectedState = await getCurrentState(fixture, validators);
+    await showState(
+      "After registering",
+      await getCurrentState(fixture, validators)
     );
+    await ethdkg.minorSlash(validators[0], validators[1]);
+    await showState(
+      "After minor slashing",
+      await getCurrentState(fixture, validators)
+    );
+
+    let currentState = await getCurrentState(fixture, validators);
+    // Expect infringer validator position to be unregister and not StakeNFT position to be created
+    expectedState.ValidatorPool.ValNFT--;
+
+    // Expect infringer to loose the validator position and the accusator to have all the funds gained
+    // as reward
+    expectedState.ValidatorNFT.MAD -= stakeAmount;
+    expectedState.validators[1].MAD += stakeAmount;
+    expectedState.validators[0].Acc = false;
+    expectedState.validators[0].ExQ = false;
+    expectedState.validators[0].Reg = false;
+    await showState("Expected state", expectedState);
+    await showState("Current state", currentState);
+    expect(currentState).to.be.deep.equal(expectedState);
   });
 });

--- a/bridge/test/validatorPool/invalid-access-control.test.ts
+++ b/bridge/test/validatorPool/invalid-access-control.test.ts
@@ -35,10 +35,48 @@ describe("ValidatorPool Access Control: An user without admin role should not be
     ).to.be.revertedWith("onlyFactory");
   });
 
+  it("Set disputer reward", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).setDisputerReward(1)
+    ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Set stake Amount", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).setStakeAmount(1)
+    ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Initialize ETHDKG", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).initializeETHDKG()
+    ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Complete ETHDKG", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).completeETHDKG()
+    ).to.be.revertedWith("onlyETHDKG");
+  });
+
   it("Schedule maintenance", async function () {
     await expect(
       fixture.validatorPool.connect(notAdmin1Signer).scheduleMaintenance()
     ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Pause consensus on arbitrary height", async function () {
+    await expect(
+      fixture.validatorPool
+        .connect(notAdmin1Signer)
+        .pauseConsensusOnArbitraryHeight(1)
+    ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Pause consensus", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).pauseConsensus()
+    ).to.be.revertedWith("onlySnapshots");
   });
 
   it("Register validators", async function () {
@@ -46,12 +84,6 @@ describe("ValidatorPool Access Control: An user without admin role should not be
       fixture.validatorPool
         .connect(notAdmin1Signer)
         .registerValidators(validators, stakingTokenIds)
-    ).to.be.revertedWith("onlyFactory");
-  });
-
-  it("Initialize ETHDKG", async function () {
-    await expect(
-      fixture.validatorPool.connect(notAdmin1Signer).initializeETHDKG()
     ).to.be.revertedWith("onlyFactory");
   });
 
@@ -63,11 +95,37 @@ describe("ValidatorPool Access Control: An user without admin role should not be
     ).to.be.revertedWith("onlyFactory");
   });
 
-  it("Pause consensus", async function () {
+  it("Unregister all validators", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).unregisterAllValidators()
+    ).to.be.revertedWith("onlyFactory");
+  });
+
+  it("Set location", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).setLocation("0.0.0.1")
+    ).to.be.revertedWith("ValidatorPool: Only validators allowed!");
+  });
+
+  it("Collect profit", async function () {
+    await expect(
+      fixture.validatorPool.connect(notAdmin1Signer).collectProfits()
+    ).to.be.revertedWith("ValidatorPool: Only validators allowed!");
+  });
+
+  it("Major slash a validator", async function () {
     await expect(
       fixture.validatorPool
         .connect(notAdmin1Signer)
-        .pauseConsensusOnArbitraryHeight(1)
-    ).to.be.revertedWith("onlyFactory");
+        .majorSlash(notAdmin1Signer.address, notAdmin1Signer.address)
+    ).to.be.revertedWith("onlyETHDKG");
+  });
+
+  it("Minor slash a validator", async function () {
+    await expect(
+      fixture.validatorPool
+        .connect(notAdmin1Signer)
+        .minorSlash(notAdmin1Signer.address, notAdmin1Signer.address)
+    ).to.be.revertedWith("onlyETHDKG");
   });
 });

--- a/bridge/test/validatorPool/valid-access-controls.test.ts
+++ b/bridge/test/validatorPool/valid-access-controls.test.ts
@@ -9,11 +9,9 @@ describe("ValidatorPool Access Control: An user with admin role should be able t
   let notAdmin1Signer: SignerWithAddress;
   let maxNumValidators = 5;
   let stakeAmount = 20000;
-  let validators = new Array();
   let stakingTokenIds = new Array();
 
   beforeEach(async function () {
-    validators = [];
     stakingTokenIds = [];
     fixture = await getFixture();
     const [admin, notAdmin1, , ,] = fixture.namedSigners;


### PR DESCRIPTION
## Scope

This PR is:
- Fixing the error where the validators were not being properly evicted after a minor slash in case the disputeRewards was equal to the stakeAmount (edge case)
- Fix unit tests that were failing due to race conditions 
- Add more unit tests and improve the existing ones around the ValidatorPool contract
- Replace old evm call to progress the hardhat chain during the unit tests with the new [hardhat_mine](hardhat_mine) to speed up the unit tests
- Add requirement of node version 16 in the package.json file 

