### PR TITLE
Added SVG NFT metadata for token uri on stake NFT

### DIFF
--- a/bridge/contracts/StakeNFT.sol
+++ b/bridge/contracts/StakeNFT.sol
@@ -10,6 +10,7 @@ import "contracts/utils/ERC20SafeTransfer.sol";
 import "contracts/utils/MagicValue.sol";
 import "contracts/interfaces/ICBOpener.sol";
 import "contracts/interfaces/INFTStake.sol";
+import "contracts/interfaces/INFTStakeDescriptor.sol";
 
 abstract contract StakeNFTStorage {
     // Position describes a staked position
@@ -90,7 +91,8 @@ abstract contract StakeNFTBase is
     ImmutableFactory,
     ImmutableValidatorPool,
     ImmutableMadToken,
-    ImmutableGovernance
+    ImmutableGovernance,
+    ImmutableStakeNFTPositionDescriptor
 {
     // withCircuitBreaker is a modifier to enforce the CircuitBreaker must
     // be set for a call to succeed
@@ -107,6 +109,7 @@ abstract contract StakeNFTBase is
         ImmutableMadToken()
         ImmutableGovernance()
         ImmutableValidatorPool()
+        ImmutableStakeNFTPositionDescriptor()
     {}
 
     /// gets the current value for the Eth accumulator
@@ -725,6 +728,16 @@ abstract contract StakeNFTBase is
             }
         }
         return (accumulator_, slush_);
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override(ERC721Upgradeable)
+        returns (string memory)
+    {
+        require(_exists(tokenId), "StakeNFT: Error, NFT token doesn't exist!");
+        return INFTStakeDescriptor(_StakeNFTPositionDescriptorAddress()).tokenURI(this, tokenId);
     }
 }
 

--- a/bridge/contracts/StakeNFTPositionDescriptor.sol
+++ b/bridge/contracts/StakeNFTPositionDescriptor.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.11;
+pragma abicoder v2;
+
+import "contracts/libraries/metadata/StakeNFTDescriptor.sol";
+import "contracts/interfaces/INFTStakeDescriptor.sol";
+
+/// @custom:salt StakeNFTPositionDescriptor
+/// @custom:deploy-type deployUpgradeable
+contract StakeNFTPositionDescriptor is INFTStakeDescriptor {
+    function tokenURI(INFTStake _stakeNft, uint256 tokenId)
+        external
+        view
+        override
+        returns (string memory)
+    {
+        (
+            uint256 shares,
+            uint256 freeAfter,
+            uint256 withdrawFreeAfter,
+            uint256 accumulatorEth,
+            uint256 accumulatorToken
+        ) = _stakeNft.getPosition(tokenId);
+
+        return
+            StakeNFTDescriptor.constructTokenURI(
+                StakeNFTDescriptor.ConstructTokenURIParams({
+                    tokenId: tokenId,
+                    shares: shares,
+                    freeAfter: freeAfter,
+                    withdrawFreeAfter: withdrawFreeAfter,
+                    accumulatorEth: accumulatorEth,
+                    accumulatorToken: accumulatorToken
+                })
+            );
+    }
+}

--- a/bridge/contracts/interfaces/INFTStakeDescriptor.sol
+++ b/bridge/contracts/interfaces/INFTStakeDescriptor.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import 'contracts/interfaces/INFTStake.sol';
+
+/// @title Describes a staked position NFT tokens via URI
+interface INFTStakeDescriptor {
+    /// @notice Produces the URI describing a particular token ID for a staked position
+    /// @dev Note this URI may be a data: URI with the JSON contents directly inlined
+    /// @param _stakeNft The stake NFT for which to describe the token
+    /// @param tokenId The ID of the token for which to produce a description, which may not be valid
+    /// @return The URI of the ERC721-compliant metadata
+    function tokenURI(INFTStake _stakeNft, uint256 tokenId)
+        external
+        view
+        returns (string memory);
+} 

--- a/bridge/contracts/libraries/metadata/StakeNFTDescriptor.sol
+++ b/bridge/contracts/libraries/metadata/StakeNFTDescriptor.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
+import "contracts/utils/Base64.sol";
+import "contracts/libraries/metadata/StakeNFTSVG.sol";
+
+library StakeNFTDescriptor {
+    using Strings for uint256;
+    using SafeMath for uint256;
+    using SafeMath for uint160;
+    using SafeMath for uint8;
+    using SignedSafeMath for int256;
+
+    struct ConstructTokenURIParams {
+        uint256 tokenId;
+        uint256 shares;
+        uint256 freeAfter;
+        uint256 withdrawFreeAfter;
+        uint256 accumulatorEth;
+        uint256 accumulatorToken;
+    }
+
+    function constructTokenURI(ConstructTokenURIParams memory params)
+        internal
+        pure
+        returns (string memory)
+    {
+        string memory name = generateName(params);
+        string memory descriptionPartOne = generateDescriptionPartOne();
+        string memory descriptionPartTwo = generateDescriptionPartTwo(
+            params.tokenId.toString(),
+            params.shares.toString(),
+            params.freeAfter.toString(),
+            params.withdrawFreeAfter.toString(),
+            params.accumulatorEth.toString(),
+            params.accumulatorToken.toString()
+        );
+        string memory image = Base64.encode(bytes(generateSVGImage(params)));
+
+        return
+            string(
+                abi.encodePacked(
+                    "data:application/json;base64,",
+                    Base64.encode(
+                        bytes(
+                            abi.encodePacked(
+                                '{"name":"',
+                                name,
+                                '", "description":"',
+                                descriptionPartOne,
+                                descriptionPartTwo,
+                                '", "image": "',
+                                "data:image/svg+xml;base64,",
+                                image,
+                                '"}'
+                            )
+                        )
+                    )
+                )
+            );
+    }
+
+    function escapeQuotes(string memory symbol) internal pure returns (string memory) {
+        bytes memory symbolBytes = bytes(symbol);
+        uint8 quotesCount = 0;
+        for (uint8 i = 0; i < symbolBytes.length; i++) {
+            if (symbolBytes[i] == '"') {
+                quotesCount++;
+            }
+        }
+        if (quotesCount > 0) {
+            bytes memory escapedBytes = new bytes(symbolBytes.length + (quotesCount));
+            uint256 index;
+            for (uint8 i = 0; i < symbolBytes.length; i++) {
+                if (symbolBytes[i] == '"') {
+                    escapedBytes[index++] = "\\";
+                }
+                escapedBytes[index++] = symbolBytes[i];
+            }
+            return string(escapedBytes);
+        }
+        return symbol;
+    }
+
+    function generateDescriptionPartOne() private pure returns (string memory) {
+        return
+            string(
+                abi.encodePacked(
+                    "This NFT represents a staked position on MadNET.",
+                    "\\n",
+                    "The owner of this NFT can modify or redeem the position.\\n"
+                )
+            );
+    }
+
+    function generateDescriptionPartTwo(
+        string memory tokenId,
+        string memory shares,
+        string memory freeAfter,
+        string memory withdrawFreeAfter,
+        string memory accumulatorEth,
+        string memory accumulatorToken
+    ) private pure returns (string memory) {
+        return
+            string(
+                abi.encodePacked(
+                    " Shares: ",
+                    shares,
+                    "\\nFree After: ",
+                    freeAfter,
+                    "\\nWithdraw Free After: ",
+                    withdrawFreeAfter,
+                    "\\nAccumulator Eth: ",
+                    accumulatorEth,
+                    "\\nAccumulator Token: ",
+                    accumulatorToken,
+                    "\\nToken ID: ",
+                    tokenId
+                )
+            );
+    }
+
+    function generateName(ConstructTokenURIParams memory params)
+        private
+        pure
+        returns (string memory)
+    {
+        return
+            string(
+                abi.encodePacked("MadNET Staked token for position #", params.tokenId.toString())
+            );
+    }
+
+    function generateSVGImage(ConstructTokenURIParams memory params)
+        internal
+        pure
+        returns (string memory svg)
+    {
+        StakeNFTSVG.StakeNFTSVGParams memory svgParams = StakeNFTSVG.StakeNFTSVGParams({
+            shares: params.shares.toString(),
+            freeAfter: params.freeAfter.toString(),
+            withdrawFreeAfter: params.withdrawFreeAfter.toString(),
+            accumulatorEth: params.accumulatorEth.toString(),
+            accumulatorToken: params.accumulatorToken.toString()
+        });
+
+        return StakeNFTSVG.generateSVG(svgParams);
+    }
+}

--- a/bridge/contracts/libraries/metadata/StakeNFTSVG.sol
+++ b/bridge/contracts/libraries/metadata/StakeNFTSVG.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.6;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "contracts/utils/Base64.sol";
+
+/// @title StakeNFTSVG
+/// @notice Provides a function for generating an SVG associated with a Staked NFT position
+library StakeNFTSVG {
+    using Strings for uint256;
+
+    struct StakeNFTSVGParams {
+        string shares;
+        string freeAfter;
+        string withdrawFreeAfter;
+        string accumulatorEth;
+        string accumulatorToken;
+    }
+
+    function generateSVG(StakeNFTSVGParams memory params)
+        internal
+        pure
+        returns (string memory svg)
+    {
+        return string(abi.encodePacked(generateSVGDefs(params), generateSVGText(params), "</svg>"));
+    }
+
+    function generateSVGText(StakeNFTSVGParams memory params)
+        private
+        pure
+        returns (string memory svg)
+    {
+        svg = string(
+            abi.encodePacked(
+                "<text x='10' y='20'>Shares: ",
+                params.shares,
+                "</text>",
+                "<text x='10' y='40'>Free after: ",
+                params.freeAfter,
+                "</text>",
+                "<text x='10' y='60'>Withdraw Free After: ",
+                params.withdrawFreeAfter,
+                "</text>",
+                "<text x='10' y='80'>Accumulator (ETH): ",
+                params.accumulatorEth,
+                "</text>",
+                "<text x='10' y='100'>Accumulator (Token): ",
+                params.accumulatorToken,
+                "</text>"
+            )
+        );
+    }
+
+    function generateSVGDefs(StakeNFTSVGParams memory params)
+        private
+        pure
+        returns (string memory svg)
+    {
+        svg = string(
+            abi.encodePacked(
+                '<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg"',
+                " xmlns:xlink='http://www.w3.org/1999/xlink'>"
+            )
+        );
+    }
+}

--- a/bridge/contracts/utils/Base64.sol
+++ b/bridge/contracts/utils/Base64.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+/// @title Base64
+/// @author Brecht Devos - <brecht@loopring.org>
+/// @notice Provides functions for encoding/decoding base64
+library Base64 {
+    string internal constant TABLE_ENCODE =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    bytes internal constant TABLE_DECODE =
+        hex"0000000000000000000000000000000000000000000000000000000000000000"
+        hex"00000000000000000000003e0000003f3435363738393a3b3c3d000000000000"
+        hex"00000102030405060708090a0b0c0d0e0f101112131415161718190000000000"
+        hex"001a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132330000000000";
+
+    function encode(bytes memory data) internal pure returns (string memory) {
+        if (data.length == 0) return "";
+
+        // load the table into memory
+        string memory table = TABLE_ENCODE;
+
+        // multiply by 4/3 rounded up
+        uint256 encodedLen = 4 * ((data.length + 2) / 3);
+
+        // add some extra buffer at the end required for the writing
+        string memory result = new string(encodedLen + 32);
+
+        assembly {
+            // set the actual output length
+            mstore(result, encodedLen)
+
+            // prepare the lookup table
+            let tablePtr := add(table, 1)
+
+            // input ptr
+            let dataPtr := data
+            let endPtr := add(dataPtr, mload(data))
+
+            // result ptr, jump over length
+            let resultPtr := add(result, 32)
+
+            // run over the input, 3 bytes at a time
+            for {
+
+            } lt(dataPtr, endPtr) {
+
+            } {
+                // read 3 bytes
+                dataPtr := add(dataPtr, 3)
+                let input := mload(dataPtr)
+
+                // write 4 characters
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(6, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
+                resultPtr := add(resultPtr, 1)
+            }
+
+            // padding with '='
+            switch mod(mload(data), 3)
+            case 1 {
+                mstore(sub(resultPtr, 2), shl(240, 0x3d3d))
+            }
+            case 2 {
+                mstore(sub(resultPtr, 1), shl(248, 0x3d))
+            }
+        }
+
+        return result;
+    }
+
+    function decode(string memory _data) internal pure returns (bytes memory) {
+        bytes memory data = bytes(_data);
+
+        if (data.length == 0) return new bytes(0);
+        require(data.length % 4 == 0, "invalid base64 decoder input");
+
+        // load the table into memory
+        bytes memory table = TABLE_DECODE;
+
+        // every 4 characters represent 3 bytes
+        uint256 decodedLen = (data.length / 4) * 3;
+
+        // add some extra buffer at the end required for the writing
+        bytes memory result = new bytes(decodedLen + 32);
+
+        assembly {
+            // padding with '='
+            let lastBytes := mload(add(data, mload(data)))
+            if eq(and(lastBytes, 0xFF), 0x3d) {
+                decodedLen := sub(decodedLen, 1)
+                if eq(and(lastBytes, 0xFFFF), 0x3d3d) {
+                    decodedLen := sub(decodedLen, 1)
+                }
+            }
+
+            // set the actual output length
+            mstore(result, decodedLen)
+
+            // prepare the lookup table
+            let tablePtr := add(table, 1)
+
+            // input ptr
+            let dataPtr := data
+            let endPtr := add(dataPtr, mload(data))
+
+            // result ptr, jump over length
+            let resultPtr := add(result, 32)
+
+            // run over the input, 4 characters at a time
+            for {
+
+            } lt(dataPtr, endPtr) {
+
+            } {
+                // read 4 characters
+                dataPtr := add(dataPtr, 4)
+                let input := mload(dataPtr)
+
+                // write 3 bytes
+                let output := add(
+                    add(
+                        shl(18, and(mload(add(tablePtr, and(shr(24, input), 0xFF))), 0xFF)),
+                        shl(12, and(mload(add(tablePtr, and(shr(16, input), 0xFF))), 0xFF))
+                    ),
+                    add(
+                        shl(6, and(mload(add(tablePtr, and(shr(8, input), 0xFF))), 0xFF)),
+                        and(mload(add(tablePtr, and(input, 0xFF))), 0xFF)
+                    )
+                )
+                mstore(resultPtr, shl(232, output))
+                resultPtr := add(resultPtr, 3)
+            }
+        }
+
+        return result;
+    }
+}

--- a/bridge/contracts/utils/ImmutableAuth.sol
+++ b/bridge/contracts/utils/ImmutableAuth.sol
@@ -380,4 +380,27 @@ abstract contract ImmutableATokenMinter is ImmutableFactory {
     }
 }
 
+abstract contract ImmutableStakeNFTPositionDescriptor is ImmutableFactory {
+
+    address private immutable _StakeNFTPositionDescriptor;
+
+    constructor() {
+        _StakeNFTPositionDescriptor = getMetamorphicContractAddress(0x5374616b654e4654506f736974696f6e44657363726970746f72000000000000, _factoryAddress());
+    }
+
+    modifier onlyStakeNFTPositionDescriptor() {
+        require(msg.sender == _StakeNFTPositionDescriptor, "onlyStakeNFTPositionDescriptor");
+        _;
+    }
+
+    function _StakeNFTPositionDescriptorAddress() internal view returns(address) {
+        return _StakeNFTPositionDescriptor;
+    }
+
+    function _saltForStakeNFTPositionDescriptor() internal pure returns(bytes32) {
+        return 0x5374616b654e4654506f736974696f6e44657363726970746f72000000000000;
+    }
+
+}
+
 /* solhint-enable */

--- a/bridge/scripts/pygen.py
+++ b/bridge/scripts/pygen.py
@@ -96,6 +96,7 @@ def run():
         ("AToken", "AToken"),
         ("ATokenBurner", "ATokenBurner"),
         ("ATokenMinter", "ATokenMinter"),
+        ("StakeNFTPositionDescriptor", "StakeNFTPositionDescriptor"),
         ("Foundation", "Foundation")
     ]
     c=make(clst)

--- a/bridge/test/contract-mocks/metadata/StakeNFTDescriptorMock.sol
+++ b/bridge/test/contract-mocks/metadata/StakeNFTDescriptorMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT-open-group
+pragma solidity ^0.8.11;
+
+import "contracts/libraries/metadata/StakeNFTDescriptor.sol";
+
+contract StakeNFTDescriptorMock {
+    function constructTokenURI(StakeNFTDescriptor.ConstructTokenURIParams memory params)
+        public
+        pure
+        returns (string memory)
+    {
+        return StakeNFTDescriptor.constructTokenURI(params);
+    }
+}

--- a/bridge/test/contract-mocks/metadata/StakeNFTSVGMock.sol
+++ b/bridge/test/contract-mocks/metadata/StakeNFTSVGMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT-open-group
+pragma solidity ^0.8.11;
+
+import "contracts/libraries/metadata/StakeNFTSVG.sol";
+
+contract StakeNFTSVGMock {
+    function generateSVG(StakeNFTSVG.StakeNFTSVGParams memory svgParams)
+        public
+        pure
+        returns (string memory svg)
+    {
+        return StakeNFTSVG.generateSVG(svgParams);
+    }
+}

--- a/bridge/test/setup.ts
+++ b/bridge/test/setup.ts
@@ -340,7 +340,7 @@ export const getFixture = async (
   const stakeNFTPositionDescriptor = (await deployUpgradeableWithFactory(
     factory,
     "StakeNFTPositionDescriptor"
-  )) as StakeNFTPositionDescriptor;
+  ));
 
   // ETHDKG Phases
   await deployUpgradeableWithFactory(factory, "ETHDKGPhases");

--- a/bridge/test/setup.ts
+++ b/bridge/test/setup.ts
@@ -340,7 +340,7 @@ export const getFixture = async (
   const stakeNFTPositionDescriptor = (await deployUpgradeableWithFactory(
     factory,
     "StakeNFTPositionDescriptor"
-  ));
+  )) as StakeNFTPositionDescriptor;
 
   // ETHDKG Phases
   await deployUpgradeableWithFactory(factory, "ETHDKGPhases");

--- a/bridge/test/setup.ts
+++ b/bridge/test/setup.ts
@@ -21,6 +21,7 @@ import {
   Snapshots,
   SnapshotsMock,
   StakeNFT,
+  StakeNFTPositionDescriptor,
   ValidatorNFT,
   ValidatorPool,
   ValidatorPoolMock,
@@ -47,6 +48,7 @@ export interface Fixture {
   snapshots: Snapshots | SnapshotsMock;
   ethdkg: ETHDKG;
   factory: MadnetFactory;
+  stakeNFTPositionDescriptor: StakeNFTPositionDescriptor;
   namedSigners: SignerWithAddress[];
   [key: string]: any;
 }
@@ -334,6 +336,12 @@ export const getFixture = async (
   // ETHDKG Accusations
   await deployUpgradeableWithFactory(factory, "ETHDKGAccusations");
 
+  // StakeNFTPositionDescriptor
+  const stakeNFTPositionDescriptor = (await deployUpgradeableWithFactory(
+    factory,
+    "StakeNFTPositionDescriptor"
+  )) as StakeNFTPositionDescriptor;
+
   // ETHDKG Phases
   await deployUpgradeableWithFactory(factory, "ETHDKGPhases");
 
@@ -411,6 +419,7 @@ export const getFixture = async (
     aToken,
     aTokenMinter,
     aTokenBurner,
+    stakeNFTPositionDescriptor,
   };
 };
 

--- a/bridge/test/stakeNFTDescriptor/metadata.test.ts
+++ b/bridge/test/stakeNFTDescriptor/metadata.test.ts
@@ -1,0 +1,31 @@
+import { ethers } from "hardhat"
+import { expect } from "../chai-setup"
+import { StakeNFTDescriptorMock } from "../../typechain-types/StakeNFTDescriptorMock"
+
+describe("StakeNFTDescriptor: Tests StakeNFTDescriptor methods", async () => {
+  let stakeNFTDescriptor: StakeNFTDescriptorMock
+
+  beforeEach(async function () {
+    const StakeNFTDescriptorFactory = await ethers.getContractFactory(
+      "StakeNFTDescriptorMock"
+    )
+    stakeNFTDescriptor = await StakeNFTDescriptorFactory.deploy()
+    await stakeNFTDescriptor.deployed()
+  })
+
+  it("Should return correct token uri", async function () {
+    const inputData = {
+      tokenId: 123,
+      shares: 456,
+      freeAfter: 789,
+      withdrawFreeAfter: 987,
+      accumulatorEth: 123456789,
+      accumulatorToken: 123456789
+    }
+    const expectedTokenUriData =
+      "data:application/json;base64,eyJuYW1lIjoiTWFkTkVUIFN0YWtlZCB0b2tlbiBmb3IgcG9zaXRpb24gIzEyMyIsICJkZXNjcmlwdGlvbiI6IlRoaXMgTkZUIHJlcHJlc2VudHMgYSBzdGFrZWQgcG9zaXRpb24gb24gTWFkTkVULlxuVGhlIG93bmVyIG9mIHRoaXMgTkZUIGNhbiBtb2RpZnkgb3IgcmVkZWVtIHRoZSBwb3NpdGlvbi5cbiBTaGFyZXM6IDQ1NlxuRnJlZSBBZnRlcjogNzg5XG5XaXRoZHJhdyBGcmVlIEFmdGVyOiA5ODdcbkFjY3VtdWxhdG9yIEV0aDogMTIzNDU2Nzg5XG5BY2N1bXVsYXRvciBUb2tlbjogMTIzNDU2Nzg5XG5Ub2tlbiBJRDogMTIzIiwgImltYWdlIjogImRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjNhV1IwYUQwaU5UQXdJaUJvWldsbmFIUTlJalV3TUNJZ2RtbGxkMEp2ZUQwaU1DQXdJRFV3TUNBMU1EQWlJSGh0Ykc1elBTSm9kSFJ3T2k4dmQzZDNMbmN6TG05eVp5OHlNREF3TDNOMlp5SWdlRzFzYm5NNmVHeHBibXM5SjJoMGRIQTZMeTkzZDNjdWR6TXViM0puTHpFNU9Ua3ZlR3hwYm1zblBqeDBaWGgwSUhnOUp6RXdKeUI1UFNjeU1DYytVMmhoY21Wek9pQTBOVFk4TDNSbGVIUStQSFJsZUhRZ2VEMG5NVEFuSUhrOUp6UXdKejVHY21WbElHRm1kR1Z5T2lBM09EazhMM1JsZUhRK1BIUmxlSFFnZUQwbk1UQW5JSGs5SnpZd0p6NVhhWFJvWkhKaGR5QkdjbVZsSUVGbWRHVnlPaUE1T0RjOEwzUmxlSFErUEhSbGVIUWdlRDBuTVRBbklIazlKemd3Sno1QlkyTjFiWFZzWVhSdmNpQW9SVlJJS1RvZ01USXpORFUyTnpnNVBDOTBaWGgwUGp4MFpYaDBJSGc5SnpFd0p5QjVQU2N4TURBblBrRmpZM1Z0ZFd4aGRHOXlJQ2hVYjJ0bGJpazZJREV5TXpRMU5qYzRPVHd2ZEdWNGRENDhMM04yWno0PSJ9"
+    const tokenUri = await stakeNFTDescriptor.constructTokenURI(inputData)
+
+    await expect(tokenUri).to.be.equal(expectedTokenUriData)
+  })
+})

--- a/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
+++ b/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
@@ -13,7 +13,7 @@ describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods",
   let fixture: Fixture
   let adminSigner: Signer
   let stakeNFT: StakeNFT
-
+  let stakeNFTPositionDescriptor: StakeNFTPositionDescriptor
   let stakeAmount = 20000
   let stakeAmountMadWei = ethers.utils.parseUnits(stakeAmount.toString(), 18)
   let lockTime = 1
@@ -26,6 +26,7 @@ describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods",
     adminSigner = await getValidatorEthAccount(admin.address)
 
     stakeNFT = fixture.stakeNFT
+    stakeNFTPositionDescriptor = fixture.stakeNFTPositionDescriptor
 
     await fixture.madToken.approve(
       fixture.stakeNFT.address,
@@ -45,42 +46,66 @@ describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods",
     )
   })
 
-  it("Should return correct token uri", async function () {
-    const positionData = await stakeNFT.getPosition(tokenId)
+  describe("Given valid token id", async () => {
+    let positionData
+    let svg: string
+    let tokenUriJson: string
+    let expectedTokenUriData: string
+    beforeEach(async function () {
+      positionData = await stakeNFT.getPosition(tokenId)
 
-    const svg =
-      `<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink='http://www.w3.org/1999/xlink'>` +
-      `<text x='10' y='20'>Shares: ${positionData.shares.toString()}</text>` +
-      `<text x='10' y='40'>Free after: ${positionData.freeAfter.toString()}</text>` +
-      `<text x='10' y='60'>Withdraw Free After: ${positionData.withdrawFreeAfter.toString()}</text>` +
-      `<text x='10' y='80'>Accumulator (ETH): ${positionData.accumulatorEth.toString()}</text>` +
-      `<text x='10' y='100'>Accumulator (Token): ${positionData.accumulatorToken.toString()}</text></svg>`
+      svg =
+        `<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink='http://www.w3.org/1999/xlink'>` +
+        `<text x='10' y='20'>Shares: ${positionData.shares.toString()}</text>` +
+        `<text x='10' y='40'>Free after: ${positionData.freeAfter.toString()}</text>` +
+        `<text x='10' y='60'>Withdraw Free After: ${positionData.withdrawFreeAfter.toString()}</text>` +
+        `<text x='10' y='80'>Accumulator (ETH): ${positionData.accumulatorEth.toString()}</text>` +
+        `<text x='10' y='100'>Accumulator (Token): ${positionData.accumulatorToken.toString()}</text></svg>`
 
-    const tokenUriJson =
-      `{"name":"MadNET Staked token for position #1", ` +
-      `"description":"This NFT represents a staked position on MadNET.` +
-      `\\nThe owner of this NFT can modify or redeem the position.` +
-      `\\n Shares: ${positionData.shares.toString()}` +
-      `\\nFree After: ${positionData.freeAfter.toString()}` +
-      `\\nWithdraw Free After: ${positionData.withdrawFreeAfter.toString()}` +
-      `\\nAccumulator Eth: ${positionData.accumulatorEth.toString()}` +
-      `\\nAccumulator Token: ${positionData.accumulatorToken.toString()}` +
-      `\\nToken ID: ${tokenId.toString()}", ` +
-      `"image": "data:image/svg+xml;base64,${btoa(svg)}"}`
+      tokenUriJson =
+        `{"name":"MadNET Staked token for position #1", ` +
+        `"description":"This NFT represents a staked position on MadNET.` +
+        `\\nThe owner of this NFT can modify or redeem the position.` +
+        `\\n Shares: ${positionData.shares.toString()}` +
+        `\\nFree After: ${positionData.freeAfter.toString()}` +
+        `\\nWithdraw Free After: ${positionData.withdrawFreeAfter.toString()}` +
+        `\\nAccumulator Eth: ${positionData.accumulatorEth.toString()}` +
+        `\\nAccumulator Token: ${positionData.accumulatorToken.toString()}` +
+        `\\nToken ID: ${tokenId.toString()}", ` +
+        `"image": "data:image/svg+xml;base64,${btoa(svg)}"}`
 
-    const expectedTokenUriData = `data:application/json;base64,${btoa(
-      tokenUriJson
-    )}`
+      expectedTokenUriData = `data:application/json;base64,${btoa(
+        tokenUriJson
+      )}`
+    })
 
-    const tokenUri = await stakeNFT.tokenURI(tokenId)
+    it("StakeNFTPositionDescriptor should return correct token uri", async function () {
+      const tokenUri = await stakeNFTPositionDescriptor.tokenURI(
+        stakeNFT.address,
+        tokenId
+      )
 
-    const parsedJson = JSON.parse(
-      atob(tokenUri.replace("data:application/json;base64,", ""))
-    )
+      const parsedJson = JSON.parse(
+        atob(tokenUri.replace("data:application/json;base64,", ""))
+      )
 
-    await expect(tokenUri).to.be.equal(expectedTokenUriData)
-    await expect(
-      atob(parsedJson.image.replace("data:image/svg+xml;base64,", ""))
-    ).to.be.equal(svg)
+      await expect(tokenUri).to.be.equal(expectedTokenUriData)
+      await expect(
+        atob(parsedJson.image.replace("data:image/svg+xml;base64,", ""))
+      ).to.be.equal(svg)
+    })
+
+    it("StakeNFT contract Should return correct token uri", async function () {
+      const tokenUri = await stakeNFT.tokenURI(tokenId)
+
+      const parsedJson = JSON.parse(
+        atob(tokenUri.replace("data:application/json;base64,", ""))
+      )
+
+      await expect(tokenUri).to.be.equal(expectedTokenUriData)
+      await expect(
+        atob(parsedJson.image.replace("data:image/svg+xml;base64,", ""))
+      ).to.be.equal(svg)
+    })
   })
 })

--- a/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
+++ b/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
@@ -11,10 +11,9 @@ import { StakeNFT, StakeNFTPositionDescriptor } from "../../typechain-types"
 
 describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods", async () => {
   let fixture: Fixture
-  let randomerSigner: Signer
   let adminSigner: Signer
   let stakeNFT: StakeNFT
-  let stakeNFTPositionDescriptor: StakeNFTPositionDescriptor
+
   let stakeAmount = 20000
   let stakeAmountMadWei = ethers.utils.parseUnits(stakeAmount.toString(), 18)
   let lockTime = 1
@@ -23,12 +22,10 @@ describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods",
   beforeEach(async function () {
     fixture = await getFixture(true, true)
 
-    const [admin, , , , , randomer] = fixture.namedSigners
+    const [admin] = fixture.namedSigners
     adminSigner = await getValidatorEthAccount(admin.address)
-    randomerSigner = await getValidatorEthAccount(randomer.address)
-    stakeNFT = fixture.stakeNFT
 
-    stakeNFTPositionDescriptor = fixture.stakeNFTPositionDescriptor
+    stakeNFT = fixture.stakeNFT
 
     await fixture.madToken.approve(
       fixture.stakeNFT.address,

--- a/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
+++ b/bridge/test/stakeNFTPositionDescriptor/stake-nft-metadata.test.ts
@@ -1,0 +1,89 @@
+import {
+  Fixture,
+  getFixture,
+  getTokenIdFromTx,
+  getValidatorEthAccount
+} from "../setup"
+import { ethers } from "hardhat"
+import { expect } from "../chai-setup"
+import { BigNumber, BigNumberish, Signer } from "ethers"
+import { StakeNFT, StakeNFTPositionDescriptor } from "../../typechain-types"
+
+describe("StakeNFTPositionDescriptor: Tests StakeNFTPositionDescriptor methods", async () => {
+  let fixture: Fixture
+  let randomerSigner: Signer
+  let adminSigner: Signer
+  let stakeNFT: StakeNFT
+  let stakeNFTPositionDescriptor: StakeNFTPositionDescriptor
+  let stakeAmount = 20000
+  let stakeAmountMadWei = ethers.utils.parseUnits(stakeAmount.toString(), 18)
+  let lockTime = 1
+  let tokenId: BigNumberish
+
+  beforeEach(async function () {
+    fixture = await getFixture(true, true)
+
+    const [admin, , , , , randomer] = fixture.namedSigners
+    adminSigner = await getValidatorEthAccount(admin.address)
+    randomerSigner = await getValidatorEthAccount(randomer.address)
+    stakeNFT = fixture.stakeNFT
+
+    stakeNFTPositionDescriptor = fixture.stakeNFTPositionDescriptor
+
+    await fixture.madToken.approve(
+      fixture.stakeNFT.address,
+      BigNumber.from(stakeAmountMadWei)
+    )
+    let tx = await fixture.stakeNFT
+      .connect(adminSigner)
+      .mintTo(admin.address, stakeAmountMadWei, lockTime)
+    tokenId = await getTokenIdFromTx(tx)
+  })
+
+  it("Fails if token at id does not exist", async function () {
+    const invalidTokenId = 1234
+
+    await expect(stakeNFT.tokenURI(invalidTokenId)).to.be.revertedWith(
+      "StakeNFT: Error, NFT token doesn't exist!"
+    )
+  })
+
+  it("Should return correct token uri", async function () {
+    const positionData = await stakeNFT.getPosition(tokenId)
+
+    const svg =
+      `<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink='http://www.w3.org/1999/xlink'>` +
+      `<text x='10' y='20'>Shares: ${positionData.shares.toString()}</text>` +
+      `<text x='10' y='40'>Free after: ${positionData.freeAfter.toString()}</text>` +
+      `<text x='10' y='60'>Withdraw Free After: ${positionData.withdrawFreeAfter.toString()}</text>` +
+      `<text x='10' y='80'>Accumulator (ETH): ${positionData.accumulatorEth.toString()}</text>` +
+      `<text x='10' y='100'>Accumulator (Token): ${positionData.accumulatorToken.toString()}</text></svg>`
+
+    const tokenUriJson =
+      `{"name":"MadNET Staked token for position #1", ` +
+      `"description":"This NFT represents a staked position on MadNET.` +
+      `\\nThe owner of this NFT can modify or redeem the position.` +
+      `\\n Shares: ${positionData.shares.toString()}` +
+      `\\nFree After: ${positionData.freeAfter.toString()}` +
+      `\\nWithdraw Free After: ${positionData.withdrawFreeAfter.toString()}` +
+      `\\nAccumulator Eth: ${positionData.accumulatorEth.toString()}` +
+      `\\nAccumulator Token: ${positionData.accumulatorToken.toString()}` +
+      `\\nToken ID: ${tokenId.toString()}", ` +
+      `"image": "data:image/svg+xml;base64,${btoa(svg)}"}`
+
+    const expectedTokenUriData = `data:application/json;base64,${btoa(
+      tokenUriJson
+    )}`
+
+    const tokenUri = await stakeNFT.tokenURI(tokenId)
+
+    const parsedJson = JSON.parse(
+      atob(tokenUri.replace("data:application/json;base64,", ""))
+    )
+
+    await expect(tokenUri).to.be.equal(expectedTokenUriData)
+    await expect(
+      atob(parsedJson.image.replace("data:image/svg+xml;base64,", ""))
+    ).to.be.equal(svg)
+  })
+})

--- a/bridge/test/stakeNFTSVG/stake-nft-svg.test.ts
+++ b/bridge/test/stakeNFTSVG/stake-nft-svg.test.ts
@@ -1,0 +1,29 @@
+import { ethers } from "hardhat"
+import { expect } from "../chai-setup"
+import { StakeNFTSVGMock } from "../../typechain-types"
+
+describe("StakeNFTSVG: Tests StakeNFTSVG library methods", async () => {
+  let stakeNFTSVG: StakeNFTSVGMock
+
+  beforeEach(async function () {
+    const StakeNFTSVGFactory = await ethers.getContractFactory(
+      "StakeNFTSVGMock"
+    )
+    stakeNFTSVG = await StakeNFTSVGFactory.deploy()
+    await stakeNFTSVG.deployed()
+  })
+
+  it("Should return correct token uri", async function () {
+    const inputData = {
+      shares: "shares value",
+      freeAfter: "freeAfter value",
+      withdrawFreeAfter: "withdrawFreeAfter value",
+      accumulatorEth: "accumulatorEth value",
+      accumulatorToken: "accumulatorToken value"
+    }
+    const expectedSvgData = `<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink='http://www.w3.org/1999/xlink'><text x='10' y='20'>Shares: ${inputData.shares}</text><text x='10' y='40'>Free after: ${inputData.freeAfter}</text><text x='10' y='60'>Withdraw Free After: ${inputData.withdrawFreeAfter}</text><text x='10' y='80'>Accumulator (ETH): ${inputData.accumulatorEth}</text><text x='10' y='100'>Accumulator (Token): ${inputData.accumulatorToken}</text></svg>`
+    const generatedSVG = await stakeNFTSVG.generateSVG(inputData)
+
+    await expect(generatedSVG).to.be.equal(expectedSvgData)
+  })
+})

--- a/bridge/test/validatorNFT/business-logic.ts
+++ b/bridge/test/validatorNFT/business-logic.ts
@@ -111,4 +111,47 @@ describe("ValidatorNFT: Tests ValidatorNFT Business Logic methods", async () => 
         .balanceOf(notAdminSigner.address)
     ).to.equal(madBalanceBefore.add(amount));
   });
+
+  it("Should return correct token uri", async function () {
+    let tx = await validatorPool.mintValidatorNFT();
+    await tx.wait();
+
+    const tokenId = 1;
+    const positionData = await fixture.validatorNFT.getPosition(tokenId);
+
+    const svg =
+      `<svg width="500" height="500" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink='http://www.w3.org/1999/xlink'>` +
+      `<text x='10' y='20'>Shares: ${positionData.shares.toString()}</text>` +
+      `<text x='10' y='40'>Free after: ${positionData.freeAfter.toString()}</text>` +
+      `<text x='10' y='60'>Withdraw Free After: ${positionData.withdrawFreeAfter.toString()}</text>` +
+      `<text x='10' y='80'>Accumulator (ETH): ${positionData.accumulatorEth.toString()}</text>` +
+      `<text x='10' y='100'>Accumulator (Token): ${positionData.accumulatorToken.toString()}</text></svg>`;
+
+    const tokenUriJson =
+      `{"name":"MadNET Staked token for position #1", ` +
+      `"description":"This NFT represents a staked position on MadNET.` +
+      `\\nThe owner of this NFT can modify or redeem the position.` +
+      `\\n Shares: ${positionData.shares.toString()}` +
+      `\\nFree After: ${positionData.freeAfter.toString()}` +
+      `\\nWithdraw Free After: ${positionData.withdrawFreeAfter.toString()}` +
+      `\\nAccumulator Eth: ${positionData.accumulatorEth.toString()}` +
+      `\\nAccumulator Token: ${positionData.accumulatorToken.toString()}` +
+      `\\nToken ID: ${tokenId.toString()}", ` +
+      `"image": "data:image/svg+xml;base64,${btoa(svg)}"}`;
+
+    const expectedTokenUriData = `data:application/json;base64,${btoa(
+      tokenUriJson
+    )}`;
+
+    const tokenUri = await fixture.validatorNFT.tokenURI(tokenId);
+
+    const parsedJson = JSON.parse(
+      atob(tokenUri.replace("data:application/json;base64,", ""))
+    );
+
+    await expect(tokenUri).to.be.equal(expectedTokenUriData);
+    await expect(
+      atob(parsedJson.image.replace("data:image/svg+xml;base64,", ""))
+    ).to.be.equal(svg);
+  });
 });


### PR DESCRIPTION
## Scope
Changes for [MP-267](https://madhive.atlassian.net/browse/MP-267)

- Added a token uri descriptor for the NFTs
- Added on chain svg generation for the stake positions

## Why?

Why are we doing this?

## Todos
If any, what are the follow-up tasks required other than merging this PR?  Have they been arranged?
- [ ] ???
