### PR TITLE
Added hardhat script to force the consensus to stop and to call sched…

### DIFF
--- a/bridge/scripts/lib/madnetTasks.ts
+++ b/bridge/scripts/lib/madnetTasks.ts
@@ -217,3 +217,63 @@ task(
   const event = intrface.decodeEventLog("DepositReceived", data, topics);
   console.log(event);
 });
+
+task("scheduleMaintenance", "Calls schedule Maintenance").setAction(
+  async (taskArgs, hre) => {
+    const { ethers } = hre;
+    const iface = new ethers.utils.Interface([
+      "function scheduleMaintenance()",
+    ]);
+    const input = iface.encodeFunctionData("scheduleMaintenance", []);
+    console.log("input", input);
+    const [admin] = await ethers.getSigners();
+    const adminSigner = await ethers.getSigner(admin.address);
+    const factory = await ethers.getContractAt(
+      "MadnetFactory",
+      "0x0b1f9c2b7bed6db83295c7b5158e3806d67ec5bc"
+    );
+    const validatorPool = await hre.ethers.getContractAt(
+      "ValidatorPool",
+      await factory.lookup(
+        hre.ethers.utils.formatBytes32String("ValidatorPool")
+      )
+    );
+    await (
+      await factory
+        .connect(adminSigner)
+        .callAny(validatorPool.address, 0, input)
+    ).wait();
+  }
+);
+
+task(
+  "pauseEthdkgArbritaryHeigh",
+  "Forcing consensus to stop on block number defined by --input"
+)
+  .addParam("input", "The block number after the latest block mined")
+  .setAction(async (taskArgs, hre) => {
+    const { ethers } = hre;
+    const iface = new ethers.utils.Interface([
+      "function pauseConsensusOnArbitraryHeight(uint256)",
+    ]);
+    const input = iface.encodeFunctionData("pauseConsensusOnArbitraryHeight", [
+      taskArgs.input,
+    ]);
+    const [admin] = await ethers.getSigners();
+    const adminSigner = await ethers.getSigner(admin.address);
+    const factory = await ethers.getContractAt(
+      "MadnetFactory",
+      "0x0b1f9c2b7bed6db83295c7b5158e3806d67ec5bc"
+    );
+    const validatorPool = await hre.ethers.getContractAt(
+      "ValidatorPool",
+      await factory.lookup(
+        hre.ethers.utils.formatBytes32String("ValidatorPool")
+      )
+    );
+    await (
+      await factory
+        .connect(adminSigner)
+        .callAny(validatorPool.address, 0, input)
+    ).wait();
+  });

--- a/bridge/scripts/lib/madnetTasks.ts
+++ b/bridge/scripts/lib/madnetTasks.ts
@@ -250,7 +250,7 @@ task(
   "pauseEthdkgArbritaryHeigh",
   "Forcing consensus to stop on block number defined by --input"
 )
-  .addParam("input", "The block number after the latest block mined")
+  .addParam("madnetHeight", "The block number after the latest block mined")
   .setAction(async (taskArgs, hre) => {
     const { ethers } = hre;
     const iface = new ethers.utils.Interface([

--- a/bridge/scripts/lib/madnetTasks.ts
+++ b/bridge/scripts/lib/madnetTasks.ts
@@ -218,8 +218,12 @@ task(
   console.log(event);
 });
 
-task("scheduleMaintenance", "Calls schedule Maintenance").setAction(
-  async (taskArgs, hre) => {
+task("scheduleMaintenance", "Calls schedule Maintenance")
+  .addParam(
+    "factoryAddress",
+    "the default factory address from factoryState will be used if not set"
+  )
+  .setAction(async (taskArgs, hre) => {
     const { ethers } = hre;
     const iface = new ethers.utils.Interface([
       "function scheduleMaintenance()",
@@ -230,7 +234,7 @@ task("scheduleMaintenance", "Calls schedule Maintenance").setAction(
     const adminSigner = await ethers.getSigner(admin.address);
     const factory = await ethers.getContractAt(
       "MadnetFactory",
-      "0x0b1f9c2b7bed6db83295c7b5158e3806d67ec5bc"
+      taskArgs.factoryAddress
     );
     const validatorPool = await hre.ethers.getContractAt(
       "ValidatorPool",
@@ -243,27 +247,30 @@ task("scheduleMaintenance", "Calls schedule Maintenance").setAction(
         .connect(adminSigner)
         .callAny(validatorPool.address, 0, input)
     ).wait();
-  }
-);
+  });
 
 task(
-  "pauseEthdkgArbritaryHeigh",
+  "pauseEthdkgArbitraryHeight",
   "Forcing consensus to stop on block number defined by --input"
 )
   .addParam("madnetHeight", "The block number after the latest block mined")
+  .addParam(
+    "factoryAddress",
+    "the default factory address from factoryState will be used if not set"
+  )
   .setAction(async (taskArgs, hre) => {
     const { ethers } = hre;
     const iface = new ethers.utils.Interface([
       "function pauseConsensusOnArbitraryHeight(uint256)",
     ]);
     const input = iface.encodeFunctionData("pauseConsensusOnArbitraryHeight", [
-      taskArgs.input,
+      taskArgs.madnetHeight,
     ]);
     const [admin] = await ethers.getSigners();
     const adminSigner = await ethers.getSigner(admin.address);
     const factory = await ethers.getContractAt(
       "MadnetFactory",
-      "0x0b1f9c2b7bed6db83295c7b5158e3806d67ec5bc"
+      taskArgs.factoryAddress
     );
     const validatorPool = await hre.ethers.getContractAt(
       "ValidatorPool",


### PR DESCRIPTION
## Scope

Ensuring if validators can or cannot mine Madnet blocks while ETHDKG is running, we discover a bug which was blocking the validators mining. Indeed in the previous workflow `delete(updatedState.Validators, epoch)` was necessary, but  after the latest changes this is not required anymore.

This also prove that the ticket MP-301 was actually already in place, cause as validator I will not be able to mine any blocks during ETHDKG due to it is needed all the consensus not to be halted. 