### PR TITLE
Optimize snapshots

### DIFF
--- a/bridge/contracts/ETHDKG.sol
+++ b/bridge/contracts/ETHDKG.sol
@@ -288,9 +288,11 @@ contract ETHDKG is
     }
 
     function tryGetParticipantIndex(address participant) public view returns (bool, uint256) {
-        Participant memory participantData = _participants[participant];
-        if (participantData.nonce == _nonce && _nonce != 0) {
-            return (true, _participants[participant].index);
+        uint256 participantDataIndex = _participants[participant].index;
+        uint256 participantDataNonce = _participants[participant].nonce;
+        uint256 nonce = _nonce;
+        if (participantDataNonce == nonce && nonce != 0) {
+            return (true, participantDataIndex);
         }
         return (false, 0);
     }


### PR DESCRIPTION
This PR should cut approx 25k gas costs when doing the snapshots. The ETHDKG function `tryGetValidatorIndex` is being called during the snapshots. This function was trying to retrieve the whole Participant struct from storage. Getting only the necessary fields in the struct demonstrated to be way more cost-effective. 
