### PR TITLE
Fix docker permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# upon checkout, normalize line endings (e.g. \n for UNIX, \r\n for windows)
+* text=auto !eol
+
+# don't normalize shell scripts, since carriage returns cause script errors
+*.sh text eol=lf
+*.bash text eol=lf

--- a/docker/apply-permvars-alpine.sh
+++ b/docker/apply-permvars-alpine.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# This file replicates all the permissions that the host OS saved with `set-permvars.sh` to an alpine container
+# Paste the following lines into the Dockerfile to use it:
+#
+#   ARG BUILDER_UID
+#   ARG BUILDER_GIDS
+#   ADD docker/apply-permvars-alpine.sh /
+#   RUN /apply-permvars-alpine.sh
+#   USER $BUILDER_UID
+#
+
+# skip errors, because some groups, and perhaps even the UID may already exist
+# this isn't a problem, only the UID or GID matters, not the actual name of the user or group
+set +e
+
+# create user if doesn't exist already
+adduser -D -g $BUILDER_UID container_builder
+BUILDER_NAME=$(getent passwd $BUILDER_UID | cut -d: -f1)
+
+# add all group ids that the user belongs to if they don't exist already
+echo $BUILDER_GIDS | xargs -n 1 | xargs -I % addgroup -g % group%
+
+# assign user to all group ids
+echo $BUILDER_GIDS | xargs -n 1 | xargs -I % getent group % | cut -d: -f1 | xargs -I % adduser $BUILDER_NAME %
+
+echo $BUILDER_NAME

--- a/docker/apply-permvars-alpine.sh
+++ b/docker/apply-permvars-alpine.sh
@@ -15,7 +15,7 @@
 set +e
 
 # create user if doesn't exist already
-adduser -D -g $BUILDER_UID container_builder
+adduser -D -g $BUILDER_UID -u $BUILDER_UID container_builder
 BUILDER_NAME=$(getent passwd $BUILDER_UID | cut -d: -f1)
 
 # add all group ids that the user belongs to if they don't exist already

--- a/docker/generate-bridge/Dockerfile
+++ b/docker/generate-bridge/Dockerfile
@@ -6,6 +6,8 @@ RUN go install github.com/ethereum/go-ethereum/cmd/abigen@v1.10.8
 # final node image containing binaries compiled by helper image
 FROM node:16.14.0-alpine3.15
 RUN apk add --no-cache bash=5.1.16-r0
+
+# install old npm version, because npm >=7 doesnt allow running as root :(
 RUN npm i -g npm@6.14.16
 
 # inherit all permissions from host OS

--- a/docker/generate-bridge/Dockerfile
+++ b/docker/generate-bridge/Dockerfile
@@ -6,12 +6,17 @@ RUN go install github.com/ethereum/go-ethereum/cmd/abigen@v1.10.8
 # final node image containing binaries compiled by helper image
 FROM node:16.14.0-alpine3.15
 RUN apk add --no-cache bash=5.1.16-r0
-COPY --from=go_deps /go/bin/ /usr/local/bin/
+RUN npm i -g npm@6.14.16
 
-ADD package.json package-lock.json /app/
+ARG BUILDER_UID
+ARG BUILDER_GIDS
+ADD docker/apply-permvars-alpine.sh /
+RUN /apply-permvars-alpine.sh
+USER $BUILDER_UID
+
 WORKDIR /app
+ADD --chown=$BUILDER_UID bridge/package.json bridge/package-lock.json /app/
 RUN npm ci
 
-RUN addgroup node root
-USER node
+COPY --from=go_deps /go/bin/ /usr/local/bin/
 CMD npm run build

--- a/docker/generate-bridge/Dockerfile
+++ b/docker/generate-bridge/Dockerfile
@@ -8,6 +8,7 @@ FROM node:16.14.0-alpine3.15
 RUN apk add --no-cache bash=5.1.16-r0
 RUN npm i -g npm@6.14.16
 
+# inherit all permissions from host OS
 ARG BUILDER_UID
 ARG BUILDER_GIDS
 ADD docker/apply-permvars-alpine.sh /

--- a/docker/generate-bridge/Dockerfile.dockerignore
+++ b/docker/generate-bridge/Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 **
-!package.json
-!package-lock.json
+!bridge/package.json
+!bridge/package-lock.json
+!docker/apply-permvars-alpine.sh

--- a/docker/generate-go/Dockerfile
+++ b/docker/generate-go/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.17.6-alpine3.15
 # some binaries used for code generation can be installed through package manager
 RUN apk add --no-cache protoc=3.18.1-r1 capnproto=0.8.0-r1 capnproto-dev=0.8.0-r1
 
+# inherit all permissions from host OS
 ARG BUILDER_UID
 ARG BUILDER_GIDS
 ADD docker/apply-permvars-alpine.sh /

--- a/docker/generate-go/Dockerfile
+++ b/docker/generate-go/Dockerfile
@@ -3,8 +3,14 @@ FROM golang:1.17.6-alpine3.15
 # some binaries used for code generation can be installed through package manager
 RUN apk add --no-cache protoc=3.18.1-r1 capnproto=0.8.0-r1 capnproto-dev=0.8.0-r1
 
-ADD go.mod go.sum /app/
+ARG BUILDER_UID
+ARG BUILDER_GIDS
+ADD docker/apply-permvars-alpine.sh /
+RUN /apply-permvars-alpine.sh
+USER $BUILDER_UID
+
 WORKDIR /app
+ADD --chown=$BUILDER_UID go.mod go.sum /app/
 
 # other binaries used for code generation are installed from go source
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go &&\
@@ -14,5 +20,5 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go &&\
     go install github.com/MadBase/go-capnproto2/v2/capnpc-go &&\
     go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway &&\
     go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
-    
+
 CMD go generate -x ./... 

--- a/docker/generate-go/Dockerfile.dockerignore
+++ b/docker/generate-go/Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 **
 !go.mod
 !go.sum
+!docker/apply-permvars-alpine.sh

--- a/docker/set-permvars.sh
+++ b/docker/set-permvars.sh
@@ -4,8 +4,18 @@
 # These variables can then be passed onto a container, where they can be used to recreate the user ids and groups
 # This allows us to seamlessly mount directories into containers, generate files in those containers all under the same user as is used under the host OS
 
-# the user id of the person building the image
-export BUILDER_UID=$(id -u)
+case "$(uname -s)" in
+	CYGWIN*|MINGW32*|MSYS*|MINGW*)
+		# if windows, permissions don't matter, just set to root
+		export BUILDER_UID=0;
+		export BUILDER_GIDS=0;
+		;;
 
-# the ids of all the user groups that the person building the image belongs to
-export BUILDER_GIDS=$(groups | xargs -n 1 | xargs -I % getent group % | cut -d: -f3)
+	*)
+		# the user id of the person building the image
+		export BUILDER_UID=$(id -u);
+
+		# the ids of all the user groups that the person building the image belongs to
+		export BUILDER_GIDS=$(groups | xargs -n 1 | xargs -I % getent group % | cut -d: -f3);
+		;;
+esac

--- a/docker/set-permvars.sh
+++ b/docker/set-permvars.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This file saves all the permission information of the current user into bash variables
+# These variables can then be passed onto a container, where they can be used to recreate the user ids and groups
+# This allows us to seamlessly mount directories into containers, generate files in those containers all under the same user as is used under the host OS
+
+# the user id of the person building the image
+export BUILDER_UID=$(id -u)
+
+# the ids of all the user groups that the person building the image belongs to
+export BUILDER_GIDS=$(groups | xargs -n 1 | xargs -I % getent group % | cut -d: -f3)

--- a/docker/update-container.sh
+++ b/docker/update-container.sh
@@ -18,7 +18,6 @@ CMD=${4-};
 DOCKER_BUILD_ARGS="-f $DOCKERFILE -t $TAG";
 
 PASS_PERMVARS=${PASS_PERMVARS-};
-echo PASS_PERMVARS=$PASS_PERMVARS;
 if [ "$PASS_PERMVARS" != "" ]; then
 	source ./docker/set-permvars.sh;
 	DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg BUILDER_UID --build-arg BUILDER_GIDS";

--- a/docker/update-container.sh
+++ b/docker/update-container.sh
@@ -10,16 +10,24 @@ export MSYS_NO_PATHCONV=1;
 YELLOW='\033[0;33m';
 NOCOL='\033[0m';
 
-DOCKERFILE=$1
-TAG=$2
-DOCKER_CREATE_ARGS=${3-}
-CMD=${4-}
+DOCKERFILE=$1;
+TAG=$2;
+DOCKER_CREATE_ARGS=${3-};
+CMD=${4-};
+
+DOCKER_BUILD_ARGS="-f $DOCKERFILE -t $TAG";
+
+PASS_PERMVARS=${PASS_PERMVARS-};
+echo PASS_PERMVARS=$PASS_PERMVARS;
+if [ "$PASS_PERMVARS" != "" ]; then
+	source ./docker/set-permvars.sh;
+	DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg BUILDER_UID --build-arg BUILDER_GIDS";
+fi;
 
 echo -e "$YELLOW# Building image... $NOCOL";
-DOCKER_BUILDKIT=1 docker build . -f $DOCKERFILE -t $TAG;
+DOCKER_BUILDKIT=1 docker build . $DOCKER_BUILD_ARGS;
 
 EXISTING_CONTAINER_IMAGE=$(docker ps -a --filter name=$TAG --format {{.Image}});
-
 if [ "$EXISTING_CONTAINER_IMAGE" = "$TAG" ]; then
 	IS_RUNNING=$(docker ps --filter name=$TAG --format {{.Image}});
 	if [ "$IS_RUNNING" != "" ]; then
@@ -30,8 +38,10 @@ if [ "$EXISTING_CONTAINER_IMAGE" = "$TAG" ]; then
 	echo -e "$YELLOW# Container ready! $NOCOL";
 else
 	if [ "$EXISTING_CONTAINER_IMAGE" != "" ]; then
-		echo -e "$YELLOW# Removing old container... $NOCOL";
-		docker rm -f $TAG;
+		echo -e "$YELLOW# Removing old image and container... $NOCOL";
+		docker container rm -vf $TAG;
+		docker image rm -f $EXISTING_CONTAINER_IMAGE
+		docker builder prune -f
 	fi;
 	
 	echo -e "$YELLOW# Creating new container... $NOCOL";


### PR DESCRIPTION
This PR changes the build sequence. What happens now, is that the UID of the user that runs `make generate`, and the GID of each group that that he belongs to, are saved into variables, which are then passed on to the docker build, where they are used to recreate all permissions in the container as they are on the file system. The container will run as you, and will be part of all the same groups as you. This ensures that the container can access any files that you can, and also ensures that any files created by it are under your name.

This should fix some of the permission issues we saw.

To start a new build from scratch, run:
`sudo make clean` (this is important, so that the old files that were previously created as root are now gone)
`make generate`