### PR TITLE
add tests to consensus/objs

### DIFF
--- a/consensus/gossip/state_test.go
+++ b/consensus/gossip/state_test.go
@@ -58,6 +58,17 @@ func TestState(t *testing.T) {
 	_ = nrl
 	_ = nhl
 	_ = bh
+
+	cert, err := nrl.MakeRoundCert(bnSigners[0], bnShares)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cert.ValidateSignature(&crypto.BNGroupValidator{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = DB.Update(func(txn *badger.Txn) error {
 		vs := makeValidatorSet(1, groupk, secpSigners, bnSigners)
 		err := database.SetValidatorSet(txn, vs)

--- a/consensus/objs/nh_test.go
+++ b/consensus/objs/nh_test.go
@@ -124,6 +124,15 @@ func TestNextHeight(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	nhcbytes, err := nh.NHClaims.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nhc := nh2.NHClaims
+	err = nhc.UnmarshalBinary(nhcbytes)
+	if err != nil {
+		t.Fatal(err)
+	}
 	nh3, err := nh2.Plagiarize(secpSigner, gk)
 	if err != nil {
 		t.Fatal(err)

--- a/consensus/objs/nr_test.go
+++ b/consensus/objs/nr_test.go
@@ -1,6 +1,7 @@
 package objs
 
 import (
+	"github.com/MadBase/MadNet/constants"
 	"testing"
 
 	"github.com/MadBase/MadNet/crypto"
@@ -69,5 +70,59 @@ func TestNextRound(t *testing.T) {
 	err = nr2.ValidateSignatures(secpVal, bnVal)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	nrcBytes, err := nr2.NRClaims.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nrcl := &NRClaims{}
+	err = nrcl.UnmarshalBinary(nrcBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nrcl.RClaims.Height++
+	nrclBytes, err := nrcl.MarshalBinary()
+	nrcErr := &NRClaims{}
+	err = nrcErr.UnmarshalBinary(nrclBytes)
+	if err == nil {
+		t.Fatal("Should have raised error (1)")
+	}
+
+	nrcl.RClaims.Height--
+	nrcl.RClaims.Round++
+	nrclBytes, err = nrcl.MarshalBinary()
+	nrcErr = &NRClaims{}
+	err = nrcErr.UnmarshalBinary(nrclBytes)
+	if err == nil {
+		t.Fatal("Should have raised error (2)")
+	}
+
+	nrcl.RClaims.Round--
+	nrcl.RClaims.ChainID++
+	nrclBytes, err = nrcl.MarshalBinary()
+	nrcErr = &NRClaims{}
+	err = nrcErr.UnmarshalBinary(nrclBytes)
+	if err == nil {
+		t.Fatal("Should have raised error (3)")
+	}
+
+	nrcl.RClaims.ChainID--
+	nrcl.RClaims.PrevBlock = make([]byte, constants.HashLen)
+	nrclBytes, err = nrcl.MarshalBinary()
+	nrcErr = &NRClaims{}
+	err = nrcErr.UnmarshalBinary(nrclBytes)
+	if err == nil {
+		t.Fatal("Should have raised error (4)")
+	}
+
+	nrcl.RClaims.PrevBlock = []byte{1, 2, 3}
+	nrclBytes, err = nrcl.MarshalBinary()
+	nrcErr = &NRClaims{}
+	err = nrcErr.UnmarshalBinary(nrclBytes)
+	if err == nil {
+		t.Fatal("Should have raised error (5)")
 	}
 }

--- a/consensus/objs/os_test.go
+++ b/consensus/objs/os_test.go
@@ -1,0 +1,107 @@
+package objs
+
+import (
+	"github.com/MadBase/MadNet/crypto"
+	bn256 "github.com/MadBase/MadNet/crypto/bn256/cloudflare"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+)
+
+func TestOwnState(t *testing.T) {
+	//Vaddr
+	secret1 := big.NewInt(100)
+	secret2 := big.NewInt(101)
+	secret3 := big.NewInt(102)
+	secret4 := big.NewInt(103)
+
+	big1 := big.NewInt(1)
+	big2 := big.NewInt(2)
+
+	privCoefs1 := []*big.Int{secret1, big1, big2}
+	privCoefs2 := []*big.Int{secret2, big1, big2}
+	privCoefs3 := []*big.Int{secret3, big1, big2}
+	privCoefs4 := []*big.Int{secret4, big1, big2}
+
+	share1to1 := bn256.PrivatePolyEval(privCoefs1, 1)
+	share2to1 := bn256.PrivatePolyEval(privCoefs2, 1)
+	share3to1 := bn256.PrivatePolyEval(privCoefs3, 1)
+	share4to1 := bn256.PrivatePolyEval(privCoefs4, 1)
+
+	listOfSS1 := []*big.Int{share1to1, share2to1, share3to1, share4to1}
+	gsk1 := bn256.GenerateGroupSecretKeyPortion(listOfSS1)
+	gpk1 := new(bn256.G2).ScalarBaseMult(gsk1)
+
+	secpSigner := &crypto.Secp256k1Signer{}
+	err := secpSigner.SetPrivk(crypto.Hasher(gpk1.Marshal()))
+	if err != nil {
+		panic(err)
+	}
+	secpKey, err := secpSigner.Pubkey()
+	if err != nil {
+		panic(err)
+	}
+
+	//BlockHeader
+	bclaimsList, txHashListList, err := generateChain(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bclaims := bclaimsList[0]
+	bhsh, err := bclaims.BlockHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gk := crypto.BNGroupSigner{}
+	err = gk.SetPrivk(crypto.Hasher([]byte("secret")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := gk.Sign(bhsh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bh := &BlockHeader{
+		BClaims:  bclaims,
+		SigGroup: sig,
+		TxHshLst: txHashListList[0],
+	}
+
+	os := &OwnState{}
+	os = nil
+	binary, err := os.MarshalBinary()
+	if err == nil {
+		t.Fatal("Should raise an error")
+	}
+
+	err = os.UnmarshalBinary(binary)
+	if err == nil {
+		t.Fatal("Should raise an error")
+	}
+
+	os = &OwnState{
+		VAddr:             secpKey,
+		SyncToBH:          bh,
+		MaxBHSeen:         bh,
+		CanonicalSnapShot: bh,
+		PendingSnapShot:   bh,
+	}
+
+	binary, err = os.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.UnmarshalBinary(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newOs, err := os.Copy()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isSync := newOs.IsSync()
+	assert.True(t, isSync)
+}

--- a/consensus/objs/pc_test.go
+++ b/consensus/objs/pc_test.go
@@ -102,4 +102,13 @@ func TestPreCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	preVotes, err := pc2.MakeImplPreVotes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(preVotes) != 2 {
+		t.Fatal("invalid preVotes length")
+	}
 }

--- a/consensus/objs/pclms_test.go
+++ b/consensus/objs/pclms_test.go
@@ -1,6 +1,7 @@
 package objs
 
 import (
+	"github.com/MadBase/MadNet/constants"
 	"testing"
 
 	"github.com/MadBase/MadNet/crypto"
@@ -65,4 +66,38 @@ func TestPClaims(t *testing.T) {
 		t.Fatal(err)
 	}
 	bclaimsEqual(t, pclms.BClaims, pclms2.BClaims)
+
+	pclms2.BClaims.ChainID++
+	pclms2Bytes, err := pclms2.MarshalBinary()
+	pclms2Err := &PClaims{}
+	err = pclms2Err.UnmarshalBinary(pclms2Bytes)
+	if err == nil {
+		t.Fatal("Should have raised error (1)")
+	}
+
+	pclms2.BClaims.ChainID--
+	pclms2.BClaims.Height++
+	pclms2Bytes, err = pclms2.MarshalBinary()
+	pclms2Err = &PClaims{}
+	err = pclms2Err.UnmarshalBinary(pclms2Bytes)
+	if err == nil {
+		t.Fatal("Should have raised error (2)")
+	}
+
+	pclms2.BClaims.Height--
+	pclms2.BClaims.PrevBlock = make([]byte, constants.HashLen)
+	pclms2Bytes, err = pclms2.MarshalBinary()
+	pclms2Err = &PClaims{}
+	err = pclms2Err.UnmarshalBinary(pclms2Bytes)
+	if err == nil {
+		t.Fatal("Should have raised error (3)")
+	}
+
+	pclms2.BClaims.PrevBlock = []byte{1, 2, 3}
+	pclms2Bytes, err = pclms2.MarshalBinary()
+	pclms2Err = &PClaims{}
+	err = pclms2Err.UnmarshalBinary(pclms2Bytes)
+	if err == nil {
+		t.Fatal("Should have raised error (3)")
+	}
 }

--- a/consensus/objs/state_test.go
+++ b/consensus/objs/state_test.go
@@ -1,8 +1,10 @@
 package objs
 
 import (
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/MadBase/MadNet/crypto"
 	bn256 "github.com/MadBase/MadNet/crypto/bn256/cloudflare"
@@ -18,10 +20,49 @@ func TestState(t *testing.T) {
 	_ = bnShares
 	vs := makeValidatorSet(1, groupk, secpSigners, bnSigners)
 	_ = vs
-	height := uint32(1)
+	height := uint32(2)
 	round := uint32(1)
 	prevBlock := crypto.Hasher([]byte("0"))
-	buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+	_, pr1, _, _, _, _, nrl, _, _ := buildRound(t, bnSigners, bnShares, secpSigners, height, round, prevBlock)
+
+	cert, err := nrl.MakeRoundCert(bnSigners[0], bnShares)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cert.ValidateSignature(&crypto.BNGroupValidator{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ovs := OwnValidatingState{
+		ValidValue:  pr1[0],
+		LockedValue: pr1[0],
+	}
+
+	ovs.SetRoundStarted()
+	ovs.SetPreCommitStepStarted()
+	ovs.SetPreVoteStepStarted()
+
+	ptoExpired := ovs.PTOExpired(100 * time.Second)
+	assert.False(t, ptoExpired)
+	pvtoExpired := ovs.PVTOExpired(100 * time.Second)
+	assert.False(t, pvtoExpired)
+	pctoExpired := ovs.PCTOExpired(100 * time.Second)
+	assert.True(t, pctoExpired)
+	dbrnrExpired := ovs.DBRNRExpired(100 * time.Second)
+	assert.True(t, dbrnrExpired)
+
+	bn, err := ovs.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ovs2 := &OwnValidatingState{}
+	err = ovs2.UnmarshalBinary(bn)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func makeSecpSigner(seed []byte) (*crypto.Secp256k1Signer, []byte) {
@@ -137,6 +178,13 @@ func buildRound(t *testing.T, bnSigners []*crypto.BNGroupSigner, groupShares [][
 			TxHshLst: [][]byte{},
 			BClaims:  bc,
 		}
+		ppsl, err := bheader.MakeDeadBlockRoundProposal(rc, crypto.Hasher([]byte{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ppsl == nil {
+			t.Fatal("invalid Dead Block Round proposal")
+		}
 		bhsh, err := bheader.BlockHash()
 		if err != nil {
 			t.Fatal(err)
@@ -161,12 +209,28 @@ func buildRound(t *testing.T, bnSigners []*crypto.BNGroupSigner, groupShares [][
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		ppsl, err := pvl.GetProposal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ppsl == nil {
+			t.Fatal("invalid proposal")
+		}
 		pcl = append(pcl, pcc)
 	}
 	for i := 0; i < len(secpSigners); i++ {
 		nh, err := pcl.MakeNextHeight(secpSigners[i], bnSigners[i])
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		ppsl, err := pcl.GetProposal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ppsl == nil {
+			t.Fatal("invalid proposal")
 		}
 		nhl = append(nhl, nh)
 	}

--- a/consensus/objs/v_test.go
+++ b/consensus/objs/v_test.go
@@ -1,0 +1,27 @@
+package objs
+
+import "testing"
+
+func TestValidator(t *testing.T) {
+	_, bnSigners, _, secpSigners, _ := makeSigners2(t)
+
+	for i, ss := range secpSigners {
+		groupKey, _ := bnSigners[i].PubkeyShare()
+		secpKey, _ := ss.Pubkey()
+		val := &Validator{
+			VAddr:      secpKey, // change
+			GroupShare: groupKey,
+		}
+
+		bt, err := val.MarshalBinary()
+		if err != nil {
+			t.Fatalf("Error MarshalBinary: %v", err)
+		}
+		newVal := &Validator{}
+		err = newVal.UnmarshalBinary(bt)
+
+		if err != nil {
+			t.Fatalf("Error UnmarshalBinary: %v", err)
+		}
+	}
+}

--- a/consensus/objs/vs_test.go
+++ b/consensus/objs/vs_test.go
@@ -1,0 +1,38 @@
+package objs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidatorsSet(t *testing.T) {
+	groupk, bnSigners, bnShares, secpSigners, secpPubks := makeSigners2(t)
+	_ = secpPubks
+	_ = bnShares
+	vs := makeValidatorSet(1, groupk, secpSigners, bnSigners)
+
+	bt, err := vs.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Error MarshalBinary: %v", err)
+	}
+	newVs := &ValidatorSet{}
+	err = newVs.UnmarshalBinary(bt)
+
+	if err != nil {
+		t.Fatalf("Error UnmarshalBinary: %v", err)
+	}
+
+	isGroupShareValidator, groupShareIdx := newVs.GroupShareIdx(vs.Validators[1].GroupShare)
+	assert.True(t, isGroupShareValidator)
+	assert.Equal(t, 1, groupShareIdx)
+
+	isValidator, valIdx := newVs.VAddrIdx(vs.Validators[2].VAddr)
+	assert.True(t, isValidator)
+	assert.Equal(t, 2, valIdx)
+
+	isValidTuple := newVs.IsValidTuple(vs.Validators[0].VAddr, vs.GroupKey)
+	assert.True(t, isValidTuple)
+
+	isValidTriplet := newVs.IsValidTriplet(vs.Validators[0].VAddr, vs.Validators[0].GroupShare, vs.GroupKey)
+	assert.True(t, isValidTriplet)
+}


### PR DESCRIPTION
## Scope
Adding and correcting tests for the following packages inside `consensus`:
`objs`: 73% coverage

## Why?
Increase code robustness
