### PR TITLE
Deposited events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 local-geth/*
+.vscode/settings.json
 
 # output files
 /madnet

--- a/blockchain/contracts.go
+++ b/blockchain/contracts.go
@@ -34,6 +34,8 @@ type ContractDetails struct {
 	validatorPoolAddress    common.Address
 	governance              *bindings.Governance
 	governanceAddress       common.Address
+	depositNotifier         *bindings.DepositNotifier
+	depositNotifierAddress  common.Address
 }
 
 // LookupContracts uses the registry to lookup and create bindings for all required contracts
@@ -152,6 +154,16 @@ func (c *ContractDetails) LookupContracts(ctx context.Context, contractFactoryAd
 		c.snapshots, err = bindings.NewSnapshots(c.snapshotsAddress, eth.client)
 		logAndEat(logger, err)
 
+		// DepositNotifier
+		c.depositNotifierAddress, err = lookup("DepositNotifier")
+		logAndEat(logger, err)
+		if bytes.Equal(c.depositNotifierAddress.Bytes(), make([]byte, 20)) {
+			continue
+		}
+
+		c.depositNotifier, err = bindings.NewDepositNotifier(c.depositNotifierAddress, eth.client)
+		logAndEat(logger, err)
+
 		break
 	}
 
@@ -228,4 +240,12 @@ func (c *ContractDetails) Governance() *bindings.Governance {
 
 func (c *ContractDetails) GovernanceAddress() common.Address {
 	return c.governanceAddress
+}
+
+func (c *ContractDetails) DepositNotifier() *bindings.DepositNotifier {
+	return c.depositNotifier
+}
+
+func (c *ContractDetails) DepositNotifierAddress() common.Address {
+	return c.depositNotifierAddress
 }

--- a/blockchain/interfaces/ethereum.go
+++ b/blockchain/interfaces/ethereum.go
@@ -147,6 +147,8 @@ type Contracts interface {
 	ValidatorPoolAddress() common.Address
 	Governance() *bindings.Governance
 	GovernanceAddress() common.Address
+	DepositNotifier() *bindings.DepositNotifier
+	DepositNotifierAddress() common.Address
 }
 
 // Task the interface requirements of a task

--- a/blockchain/monitor/event_setup.go
+++ b/blockchain/monitor/event_setup.go
@@ -187,7 +187,13 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, adminHandler interfac
 		panic("could not find event DepositNotifier.Deposited")
 	}
 
-	if err := em.RegisterLocked(depositedEvent.ID.String(), depositedEvent.Name, monevents.ProcessDeposited); err != nil {
+	if err := em.RegisterLocked(
+		depositedEvent.ID.String(),
+		depositedEvent.Name,
+		func(eth interfaces.Ethereum, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+			return monevents.ProcessDeposited(eth, logger, state, log, cdb)
+		},
+	); err != nil {
 		panic(err)
 	}
 

--- a/blockchain/monitor/event_setup.go
+++ b/blockchain/monitor/event_setup.go
@@ -68,6 +68,14 @@ func GetPublicStakingEvents() map[string]abi.Event {
 
 	return publicStakingABI.Events
 }
+func GetDepositNotifierEvents() map[string]abi.Event {
+	depositNotifierABI, err := abi.JSON(strings.NewReader(bindings.DepositNotifierMetaData.ABI))
+	if err != nil {
+		panic(err)
+	}
+
+	return depositNotifierABI.Events
+}
 
 func RegisterETHDKGEvents(em *objects.EventMap, adminHandler interfaces.AdminHandler) {
 	ethDkgEvents := GetETHDKGEvents()
@@ -169,6 +177,17 @@ func SetupEventMap(em *objects.EventMap, cdb *db.Database, adminHandler interfac
 	}
 
 	if err := em.RegisterLocked(validatorMajorSlashedEvent.ID.String(), validatorMajorSlashedEvent.Name, monevents.ProcessValidatorMajorSlashed); err != nil {
+		panic(err)
+	}
+
+	// DepositNotifier.Deposited
+	dnEvents := GetDepositNotifierEvents()
+	depositedEvent, ok := dnEvents["Deposited"]
+	if !ok {
+		panic("could not find event DepositNotifier.Deposited")
+	}
+
+	if err := em.RegisterLocked(depositedEvent.ID.String(), depositedEvent.Name, monevents.ProcessDeposited); err != nil {
 		panic(err)
 	}
 

--- a/blockchain/monitor/monevents/processors.go
+++ b/blockchain/monitor/monevents/processors.go
@@ -7,7 +7,6 @@ import (
 
 	aobjs "github.com/MadBase/MadNet/application/objs"
 	"github.com/MadBase/MadNet/blockchain/interfaces"
-	"github.com/MadBase/MadNet/blockchain/objects"
 	bobjs "github.com/MadBase/MadNet/blockchain/objects"
 	"github.com/MadBase/MadNet/consensus/db"
 	"github.com/MadBase/MadNet/consensus/objs"
@@ -65,7 +64,7 @@ func ProcessDepositReceived(eth interfaces.Ethereum, logger *logrus.Entry, state
 }
 
 // ProcessValueUpdated handles a dynamic value updating coming from our smart contract
-func ProcessValueUpdated(eth interfaces.Ethereum, logger *logrus.Entry, state *objects.MonitorState, log types.Log,
+func ProcessValueUpdated(eth interfaces.Ethereum, logger *logrus.Entry, state *bobjs.MonitorState, log types.Log,
 	adminHandler interfaces.AdminHandler) error {
 
 	logger.Info("ProcessValueUpdated() ...")
@@ -152,7 +151,7 @@ func ProcessSnapshotTaken(eth interfaces.Ethereum, logger *logrus.Entry, state *
 }
 
 // ProcessValidatorMinorSlashed handles the Minor Slash event
-func ProcessValidatorMinorSlashed(eth interfaces.Ethereum, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+func ProcessValidatorMinorSlashed(eth interfaces.Ethereum, logger *logrus.Entry, state *bobjs.MonitorState, log types.Log) error {
 
 	logger.Info("ProcessValidatorMinorSlashed() ...")
 
@@ -172,7 +171,7 @@ func ProcessValidatorMinorSlashed(eth interfaces.Ethereum, logger *logrus.Entry,
 }
 
 // ProcessValidatorMajorSlashed handles the Major Slash event
-func ProcessValidatorMajorSlashed(eth interfaces.Ethereum, logger *logrus.Entry, state *objects.MonitorState, log types.Log) error {
+func ProcessValidatorMajorSlashed(eth interfaces.Ethereum, logger *logrus.Entry, state *bobjs.MonitorState, log types.Log) error {
 
 	logger.Info("ProcessValidatorMajorSlashed() ...")
 
@@ -186,6 +185,25 @@ func ProcessValidatorMajorSlashed(eth interfaces.Ethereum, logger *logrus.Entry,
 	})
 
 	logger.Infof("ValidatorMajorSlashed")
+
+	return nil
+}
+
+// ProcessDeposited handles the Deposited event
+func ProcessDeposited(eth interfaces.Ethereum, logger *logrus.Entry, state *bobjs.MonitorState, log types.Log) error {
+
+	event, err := eth.Contracts().DepositNotifier().ParseDeposited(log)
+	if err != nil {
+		return err
+	}
+
+	logger.WithFields(logrus.Fields{
+		"Nonce":       event.Nonce.String(),
+		"ErcContract": event.ErcContract.String(),
+		"Owner":       event.Owner.String(),
+		"Number":      event.Number.String(),
+		"NetworkId":   event.NetworkId.String(),
+	}).Infof("Deposited")
 
 	return nil
 }

--- a/blockchain/monitor/monitor.go
+++ b/blockchain/monitor/monitor.go
@@ -333,7 +333,7 @@ func MonitorTick(ctx context.Context, cf context.CancelFunc, wg *sync.WaitGroup,
 		"EthereumInSync": monitorState.EthereumInSync})
 
 	c := eth.Contracts()
-	addresses := []common.Address{c.EthdkgAddress(), c.SnapshotsAddress(), c.BTokenAddress()}
+	addresses := []common.Address{c.EthdkgAddress(), c.SnapshotsAddress(), c.BTokenAddress(), c.DepositNotifierAddress()}
 
 	// 1. Check if our Ethereum endpoint is sync with sufficient peers
 	inSync, peerCount, err := EndpointInSync(ctx, eth, logger)

--- a/bridge/contracts/DepositNotifier.sol
+++ b/bridge/contracts/DepositNotifier.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT-open-group
+pragma solidity ^0.8.0;
+
+import "contracts/utils/ImmutableAuth.sol";
+
+/// @custom:salt DepositNotifier
+/// @custom:deploy-type deployUpgradeable
+contract DepositNotifier is ImmutableFactory {
+    uint256 internal _nonce = 0;
+    uint256 internal immutable _networkId;
+
+    event Deposited(
+        uint256 nonce,
+        address ercContract,
+        address owner,
+        uint256 number, // If fungible, this is the amount. If non-fungible, this is the id
+        uint256 networkId
+    );
+
+    constructor(uint256 id) ImmutableFactory(msg.sender) {
+        _networkId = id;
+    }
+
+    function doEmit(bytes32 salt, address ercContract, uint256 number, address owner) onlyFactoryChildren(salt) public {
+        uint256 n = _nonce + 1;
+        emit Deposited(n, ercContract, owner, number, _networkId);
+        _nonce = n;
+    }    
+}

--- a/bridge/contracts/libraries/errorCodes/ImmutableAuthErrorCodes.sol
+++ b/bridge/contracts/libraries/errorCodes/ImmutableAuthErrorCodes.sol
@@ -20,4 +20,5 @@ library ImmutableAuthErrorCodes {
     bytes32 public constant IMMUTEABLEAUTH_ONLY_ETHDKGACCUSATIONS = "2014"; // "onlyETHDKGAccusations"
     bytes32 public constant IMMUTEABLEAUTH_ONLY_ETHDKGPHASES = "2015"; // "onlyETHDKGPhases"
     bytes32 public constant IMMUTEABLEAUTH_ONLY_ETHDKG = "2016"; // "onlyETHDKG"
+    bytes32 public constant IMMUTEABLEAUTH_ONLY_FACTORY_CHILDREN = "2017"; // "onlyFactoryChildren"
 }

--- a/bridge/contracts/utils/ImmutableAuth.sol
+++ b/bridge/contracts/utils/ImmutableAuth.sol
@@ -15,6 +15,17 @@ abstract contract ImmutableFactory is DeterministicAddress {
         );
         _;
     }
+    
+    // this modifier asserts that the msg.sender was deployed through the factory (with the given salt)
+    modifier onlyFactoryChildren(bytes32 salt) {
+        address expected = getMetamorphicContractAddress(salt, _factoryAddress());
+        require(
+            msg.sender == expected,
+            string(abi.encodePacked(ImmutableAuthErrorCodes.IMMUTEABLEAUTH_ONLY_FACTORY_CHILDREN))
+        );
+        _;
+    }
+
 
     constructor(address factory_) {
         _factory = factory_;

--- a/bridge/hardhat.config.ts
+++ b/bridge/hardhat.config.ts
@@ -251,6 +251,7 @@ const config: HardhatUserConfig = {
       "PublicStaking",
       "ValidatorStaking",
       "Governance",
+      "DepositNotifier",
     ],
     except: [
       "I[A-Z].*",

--- a/bridge/scripts/lib/alicenetFactoryTasks.ts
+++ b/bridge/scripts/lib/alicenetFactoryTasks.ts
@@ -1076,7 +1076,7 @@ function extractPath(qualifiedName: string) {
  * @param varName
  * @returns
  */
-function getEventVar(
+export function getEventVar(
   receipt: ContractReceipt,
   eventName: string,
   varName: string

--- a/bridge/test/contract-mocks/callAny/CallAny.sol
+++ b/bridge/test/contract-mocks/callAny/CallAny.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT-open-group
+pragma solidity >=0.7.0 <0.9.0;
+
+/// @custom:salt CallAny
+/// @custom:deploy-type deployUpgradeable
+contract CallAny {
+    function callAny(address target_, uint256 value_, bytes memory cdata_) public {
+        assembly {
+            let size := mload(cdata_)
+            let ptr := add(0x20, cdata_)
+            if iszero(call(gas(), target_, value_, ptr, size, 0x00, 0x00)) {
+                returndatacopy(0x00, 0x00, returndatasize())
+                revert(0x00, returndatasize())
+            }
+            returndatacopy(0x00, 0x00, returndatasize())
+            return(0x00, returndatasize())
+        }
+    }
+}

--- a/bridge/test/depositNotifier/depositNotifier.test.ts
+++ b/bridge/test/depositNotifier/depositNotifier.test.ts
@@ -1,0 +1,82 @@
+import { ethers } from "hardhat";
+import { deployAliceNetFactory, deployUpgradeableWithFactory, preFixtureSetup, expect } from "../setup"
+import { DepositNotifier, CallAny } from "../../typechain-types";
+
+describe('depositNotifier', () => {
+  it('admin not allowed to call doEmit', async() => {
+    await preFixtureSetup()
+    const [admin] = await ethers.getSigners();
+    const factory = await deployAliceNetFactory(admin);
+    
+    const contract = (await deployUpgradeableWithFactory(factory, "DepositNotifier", "salt1", undefined, [1])) as DepositNotifier
+    
+    await expect(
+      contract.connect(admin).doEmit(
+        ethers.utils.formatBytes32String("salt1"), "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 1337, "0xcd3B766CCDd6AE721141F452C550Ca635964ce71",
+      ).then(resp => resp.wait())
+    ).to.be.rejectedWith("not allowed")
+  })
+  
+  it("doEmit succeeds when factory-deployed contract is calls it with its own salt", async() => {
+    await preFixtureSetup()
+    const [admin] = await ethers.getSigners();
+    const factory = await deployAliceNetFactory(admin);
+    
+    const dnContract = (await deployUpgradeableWithFactory(factory, "DepositNotifier", "salt1", undefined, [777])) as DepositNotifier
+    const auxillaryContract = (await deployUpgradeableWithFactory(factory, "CallAny", "salt2")) as CallAny
+    
+    const encodedArgs = dnContract.interface.encodeFunctionData(
+      "doEmit",
+      [ ethers.utils.formatBytes32String("salt2"), "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 1337, "0xcd3B766CCDd6AE721141F452C550Ca635964ce71" ]
+    )
+    const receipt = await auxillaryContract.connect(admin).callAny(dnContract.address, 0, encodedArgs).then(resp => resp.wait())
+
+    const encodedArgs2 = dnContract.interface.encodeFunctionData(
+      "doEmit",
+      [ ethers.utils.formatBytes32String("salt2"), "0xcf0a769a379d2aae3cf64b38abbafbe7653a6418", 42, "0x5e0d927f4bfe097e62f6b15a11aec9843f47ba90" ]
+    )
+    const receipt2 = await auxillaryContract.connect(admin).callAny(dnContract.address, 0, encodedArgs2).then(resp => resp.wait())
+    
+    if (receipt.events === undefined) {
+      throw Error("receipt 1 has no events")
+    } else {
+      const parsed = dnContract.interface.parseLog(receipt.events[0])
+      expect(parsed.name).to.eq("Deposited")
+      expect(parsed.args.nonce.toBigInt()).to.eq(1n)
+      expect(parsed.args.networkId.toBigInt()).to.eq(777n)
+      expect(parsed.args.ercContract).to.eq('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266')
+      expect(parsed.args.number.toBigInt()).to.eq(1337n)
+      expect(parsed.args.owner).to.eq('0xcd3B766CCDd6AE721141F452C550Ca635964ce71')
+    }
+
+    if (receipt2.events === undefined) {
+      throw Error("receipt 2 has no events")
+    } else {
+      const parsed = dnContract.interface.parseLog(receipt2.events[0])
+      expect(parsed.name).to.eq("Deposited")
+      expect(parsed.args.nonce.toBigInt()).to.eq(2n)
+      expect(parsed.args.networkId.toBigInt()).to.eq(777n)
+      expect(parsed.args.ercContract).to.eq('0xcF0a769A379d2aaE3Cf64b38AbBafBe7653A6418')
+      expect(parsed.args.number.toBigInt()).to.eq(42n)
+      expect(parsed.args.owner).to.eq('0x5e0d927F4Bfe097E62F6B15a11aEC9843F47Ba90')
+    }
+  })
+  
+  it("doEmit fails when factory-deployed contract is calls it with the wrong salt", async() => {
+    await preFixtureSetup()
+    const [admin] = await ethers.getSigners();
+    const factory = await deployAliceNetFactory(admin);
+    
+    const dnContract = (await deployUpgradeableWithFactory(factory, "DepositNotifier", "salt1", undefined, [1])) as DepositNotifier
+    const auxillaryContract = (await deployUpgradeableWithFactory(factory, "CallAny", "salt2")) as CallAny
+    
+    const encodedArgs = dnContract.interface.encodeFunctionData(
+      "doEmit",
+      [ ethers.utils.formatBytes32String("salt2XXX"), "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 1337, "0xcd3B766CCDd6AE721141F452C550Ca635964ce71" ]
+    )
+    
+    await expect(
+      auxillaryContract.connect(admin).callAny(dnContract.address, 0, encodedArgs).then(resp => resp.wait())    
+    ).to.be.rejectedWith("not allowed")
+  })
+})

--- a/cmd/testutils/simevm/main.go
+++ b/cmd/testutils/simevm/main.go
@@ -29,7 +29,10 @@ func main() {
 		1*time.Second,
 		5*time.Second,
 		0,
-		big.NewInt(math.MaxInt64))
+		big.NewInt(math.MaxInt64), 50,
+		math.MaxInt64,
+		5*time.Second,
+		30*time.Second)
 
 	if err != nil {
 		panic(err)

--- a/consensus/db/db.go
+++ b/consensus/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/MadBase/MadNet/constants/dbprefix"
@@ -1883,6 +1884,19 @@ func (db *Database) GetPendingHdrLeafKeysIter(txn *badger.Txn) *PendingHdrLeafIt
 	seek = append(seek, make([]byte, constants.HashLen)...)
 	it.Seek(seek)
 	return &PendingHdrLeafIter{it: it, prefixLen: len(prefix)}
+}
+
+func (db *Database) GetDepositedNonce(txn *badger.Txn) (*big.Int, error) {
+	b, err := db.rawDB.getValue(txn, dbprefix.PrefixDepositedNonce())
+	if err != nil {
+		return nil, err
+	}
+
+	return (&big.Int{}).SetBytes(b), nil
+}
+
+func (db *Database) SetDepositedNonce(txn *badger.Txn, i *big.Int) error {
+	return db.rawDB.SetValue(txn, dbprefix.PrefixDepositedNonce(), i.Bytes())
 }
 
 type PendingHdrLeafIter struct {

--- a/constants/dbprefix/consensus.go
+++ b/constants/dbprefix/consensus.go
@@ -130,6 +130,10 @@ func PrefixStorageNodeKey() []byte {
 	return []byte("a5")
 }
 
+func PrefixDepositedNonce() []byte {
+	return []byte("a6")
+}
+
 func PrefixPendingNodeKeyCount() []byte {
 	return []byte("Ay")
 }

--- a/scripts/base-files/deploymentArgsTemplate
+++ b/scripts/base-files/deploymentArgsTemplate
@@ -7,6 +7,9 @@ chainID_ = "1337"
 [[constructor."contracts/Snapshots.sol:Snapshots"]]
 epochLength_ = "1024"
 
+[[constructor."contracts/DepositNotifier.sol:DepositNotifier"]]
+id = "777"
+
 [[initializer."contracts/Snapshots.sol:Snapshots"]]
 desperationDelay_ = "10"
 

--- a/scripts/base-files/deploymentList
+++ b/scripts/base-files/deploymentList
@@ -14,5 +14,6 @@ deploymentList = [
   "contracts/ValidatorStaking.sol:ValidatorStaking",
   "contracts/libraries/ethdkg/ETHDKGAccusations.sol:ETHDKGAccusations",
   "contracts/libraries/ethdkg/ETHDKGPhases.sol:ETHDKGPhases",
-  "contracts/ETHDKG.sol:ETHDKG"
+  "contracts/ETHDKG.sol:ETHDKG",
+  "contracts/DepositNotifier.sol:DepositNotifier"
 ]

--- a/scripts/base-scripts/geth-local.sh
+++ b/scripts/base-scripts/geth-local.sh
@@ -3,8 +3,6 @@ DATADIR=./local-geth/
 
 rm -rf $DATADIR
 
-make build
-
 geth --datadir $DATADIR init ./scripts/generated/genesis.json
 
 cp assets/test/keys/* $DATADIR/keystore/


### PR DESCRIPTION
Add a contract that can emit a Deposited event, to be used by other token contracts when deposits are made, that will then be picked up by the validators to update the local state on their end.

I created a new modifier that allows any of the factory contract's children to call the function that emits the event. This authentication method may perhaps just be an interim solution and be replaced with something more specific in the future.

On the Golang side of things, some scaffold code has been created so that hooks can be run when this event is emitted. Currently it just prints to the console, as the Deposit UTXO does not yet exist.