### PR TITLE
Fix race condition @ P2P client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ local-geth/*
 
 # output files
 /madnet
+/madrace
 /mngen
 **/__debug_bin
 **/*.log

--- a/peering/p2pbus.go
+++ b/peering/p2pbus.go
@@ -604,7 +604,6 @@ func (p2p *P2PClient) Status(ctx context.Context, in *pb.StatusRequest, opts ...
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
 		} else {
-
 			p2p.reqChan <- req
 		}
 	}

--- a/peering/p2pbus.go
+++ b/peering/p2pbus.go
@@ -603,9 +603,12 @@ func (p2p *P2PClient) Status(ctx context.Context, in *pb.StatusRequest, opts ...
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -618,9 +621,11 @@ func (p2p *P2PClient) GetBlockHeaders(ctx context.Context, in *pb.GetBlockHeader
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -633,9 +638,11 @@ func (p2p *P2PClient) GetMinedTxs(ctx context.Context, in *pb.GetMinedTxsRequest
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -648,9 +655,11 @@ func (p2p *P2PClient) GetPendingTxs(ctx context.Context, in *pb.GetPendingTxsReq
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -663,9 +672,11 @@ func (p2p *P2PClient) GetSnapShotNode(ctx context.Context, in *pb.GetSnapShotNod
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -678,9 +689,11 @@ func (p2p *P2PClient) GetSnapShotStateData(ctx context.Context, in *pb.GetSnapSh
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -693,9 +706,11 @@ func (p2p *P2PClient) GetSnapShotHdrNode(ctx context.Context, in *pb.GetSnapShot
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -708,9 +723,11 @@ func (p2p *P2PClient) GetPeers(ctx context.Context, in *pb.GetPeersRequest, opts
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, middleware.ErrWouldBlock
+		} else {
+			p2p.reqChan <- req
 		}
 	}
-	p2p.reqChan <- req
+
 	r := <-rchan
 	return r.resp, r.err
 }
@@ -722,9 +739,11 @@ func (p2p *P2PClient) GossipTransaction(ctx context.Context, in *pb.GossipTransa
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipTxChan <- req
 		}
 	}
-	p2p.gossipTxChan <- req
+
 	return &pb.GossipTransactionAck{}, nil
 }
 
@@ -735,9 +754,11 @@ func (p2p *P2PClient) GossipProposal(ctx context.Context, in *pb.GossipProposalM
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipProposalAck{}, nil
 }
 
@@ -748,9 +769,11 @@ func (p2p *P2PClient) GossipPreVote(ctx context.Context, in *pb.GossipPreVoteMes
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipPreVoteAck{}, nil
 }
 
@@ -761,9 +784,11 @@ func (p2p *P2PClient) GossipPreVoteNil(ctx context.Context, in *pb.GossipPreVote
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipPreVoteNilAck{}, nil
 }
 
@@ -774,9 +799,11 @@ func (p2p *P2PClient) GossipPreCommit(ctx context.Context, in *pb.GossipPreCommi
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipPreCommitAck{}, nil
 }
 
@@ -787,9 +814,11 @@ func (p2p *P2PClient) GossipPreCommitNil(ctx context.Context, in *pb.GossipPreCo
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipPreCommitNilAck{}, nil
 }
 
@@ -800,9 +829,11 @@ func (p2p *P2PClient) GossipNextRound(ctx context.Context, in *pb.GossipNextRoun
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipNextRoundAck{}, nil
 }
 
@@ -813,9 +844,11 @@ func (p2p *P2PClient) GossipNextHeight(ctx context.Context, in *pb.GossipNextHei
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipNextHeightAck{}, nil
 }
 
@@ -826,9 +859,11 @@ func (p2p *P2PClient) GossipBlockHeader(ctx context.Context, in *pb.GossipBlockH
 	default:
 		if !middleware.CanBlock(opts...) {
 			return nil, ErrWouldBlock
+		} else {
+			p2p.gossipChan <- req
 		}
 	}
-	p2p.gossipChan <- req
+
 	return &pb.GossipBlockHeaderAck{}, nil
 }
 


### PR DESCRIPTION
This was a cheeky race condition. For each of its endpoints, the P2P client first attempts to send request to a request worker immediately. If it can not be handled immediately, it checks if its allowed to block for this request and if so, sends the request again and blocks until the request is eventually picked up by a request worker.

The issue, as it turns out, is that the code meant to sent the request a second time in a blocking fashion, **also** executes if the request was able to be handled synchronously, therefore handling it twice.

Not only would this bug cause the app to perform double work, it even effectively could make requests that were handled synchronously, to block as part of the erroneous second execution.

As a result, this fix should significantly increase how consistent the P2P client responds to requests.