### PR TITLE
Fix swagger reference

### DIFF
--- a/localrpc/swagger/index.html
+++ b/localrpc/swagger/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "localstate.swagger.json",
+        url: "madnet.swagger.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
## Scope

This PR is fixing the swagger endpoint

## Why?

The swagger endpoint was broken after the renaming of the swagger.json

