### PR TITLE
Multicall Multicontract Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ local-geth/*
 # generated files
 scripts/generated
 node_modules/
+bridge/dist

--- a/bridge/scripts/lib/alicenetFactoryTasks.ts
+++ b/bridge/scripts/lib/alicenetFactoryTasks.ts
@@ -1178,68 +1178,6 @@ task(
       taskArgs.inputFolder,
       taskArgs.outputFolder
     );
-    /* 
-    let txResponse = await factory.multiCall(multiCallArgsArray);
-    let receipt = await txResponse.wait();
-    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
-    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
-      staticAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
-      templateAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
-      upgradeableAddresses.push(o);
-    });
-    multiCallArgsArray = await getMulticallArgs(
-      contracts,
-      hre,
-      factoryBase,
-      factory,
-      txCount,
-      "ethdkg",
-      [0, 1],
-      taskArgs.inputFolder,
-      taskArgs.outputFolder
-    );
-    txResponse = await factory.multiCall(multiCallArgsArray);
-    receipt = await txResponse.wait();
-    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
-    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
-      staticAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
-      templateAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
-      upgradeableAddresses.push(o);
-    });
-    multiCallArgsArray = await getMulticallArgs(
-      contracts,
-      hre,
-      factoryBase,
-      factory,
-      txCount,
-      "ethdkg",
-      [2],
-      taskArgs.inputFolder,
-      taskArgs.outputFolder
-    );
-    txResponse = await factory.multiCall(multiCallArgsArray);
-    receipt = await txResponse.wait();
-    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
-    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
-      staticAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
-      templateAddresses.push(o);
-    });
-    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
-      upgradeableAddresses.push(o);
-    });
-    console.log("staticAddresses", staticAddresses);
-    console.log("upgradeableAddresses", upgradeableAddresses);
- */
     console.log(`total gas used: ${cumulativeGasUsed.toString()}`);
   });
 

--- a/bridge/scripts/lib/alicenetFactoryTasks.ts
+++ b/bridge/scripts/lib/alicenetFactoryTasks.ts
@@ -1,3 +1,4 @@
+import toml from "@iarna/toml";
 import {
   BigNumber,
   BytesLike,
@@ -15,6 +16,9 @@ import {
   DEPLOYED_PROXY,
   DEPLOYED_RAW,
   DEPLOYED_STATIC,
+  DEPLOYMENT_ARGS_TEMPLATE_FPATH,
+  DEPLOYMENT_ARG_PATH,
+  DEPLOYMENT_LIST_FPATH,
   DEPLOY_CREATE,
   DEPLOY_METAMORPHIC,
   DEPLOY_PROXY,
@@ -48,9 +52,12 @@ import {
   DeployProxyMCArgs,
   extractName,
   getAllContracts,
+  getDeployGroup,
+  getDeployGroupIndex,
   getDeployMetaArgs,
   getDeployType,
   getDeployUpgradeableProxyArgs,
+  getMulticallArgs,
   isInitializable,
 } from "./deployment/deploymentUtil";
 import {
@@ -1027,6 +1034,215 @@ task(
     return proxyData;
   });
 
+//Generate a json file with all deployment information
+task(
+  "generateContractsDescriptor",
+  "Generates deploymentList.json file for faster contract deployment (requires deploymentList and deploymentArgsTemplate files to be already generated)"
+)
+  .addOptionalParam(
+    "outputFolder",
+    "output folder path to save deployment arg template and list"
+  )
+  .setAction(async (taskArgs, hre) => {
+    await checkUserDirPath(taskArgs.outputFolder);
+    const configDirPath =
+      taskArgs.outputFolder === undefined
+        ? DEFAULT_CONFIG_OUTPUT_DIR
+        : taskArgs.outputFolder;
+    const path =
+      configDirPath === undefined
+        ? DEFAULT_CONFIG_OUTPUT_DIR + DEPLOYMENT_LIST_FPATH + ".json"
+        : configDirPath + DEPLOYMENT_LIST_FPATH + ".json";
+    const deploymentArgsPath =
+      configDirPath === undefined
+        ? DEPLOYMENT_ARG_PATH + DEPLOYMENT_ARGS_TEMPLATE_FPATH
+        : configDirPath + DEPLOYMENT_ARGS_TEMPLATE_FPATH;
+    var json = { contracts: Array<Object>() };
+    const contracts = await getDeploymentList(taskArgs.inputFolder);
+    const deploymentArgsFile = fs.readFileSync(deploymentArgsPath);
+    const tomlFile: any = toml.parse(deploymentArgsFile.toLocaleString());
+    for (let i = 0; i < contracts.length; i++) {
+      const contract = contracts[i];
+      const contractName = contract.split(":")[1];
+      const tomlConstructorArgs = tomlFile.constructor[
+        contract
+      ] as toml.JsonArray;
+      let cArgs = new Array();
+      if (tomlConstructorArgs !== undefined) {
+        tomlConstructorArgs.map((jsonObject) => {
+          cArgs.push(JSON.stringify(jsonObject).split('"')[3]);
+        });
+      }
+      const tomlInitializerArgs = tomlFile.initializer[
+        contract
+      ] as toml.JsonArray;
+      let iArgs = new Array();
+      if (tomlInitializerArgs !== undefined) {
+        tomlInitializerArgs.map((jsonObject) => {
+          iArgs.push(JSON.stringify(jsonObject).split('"')[3]);
+        });
+      }
+      const deployType = await getDeployType(contract, hre.artifacts);
+      const deployGroup = await getDeployGroup(contract, hre.artifacts);
+      const deployGroupIndex = await getDeployGroupIndex(
+        contract,
+        hre.artifacts
+      );
+      if (deployType !== undefined) {
+        var object = {
+          name: contractName,
+          fullyQualifiedName: contract,
+          deployGroup:
+            deployGroup !== undefined && deployGroup ? deployGroup : "general",
+          deployGroupIndex:
+            deployGroupIndex !== undefined && deployGroupIndex
+              ? deployGroupIndex
+              : "0",
+          deployType: deployType,
+          constructorArgs: cArgs,
+          initializerArgs: iArgs,
+        };
+        json.contracts.push(object);
+      }
+    }
+    fs.writeFileSync(path, JSON.stringify(json, null, 4));
+  });
+
+task(
+  "deployContractsFromDescriptor",
+  "Deploys ALL AliceNet contracts reading deploymentList.json"
+)
+  .addOptionalParam(
+    "factoryAddress",
+    "specify if a factory is already deployed, if not specified a new factory will be deployed"
+  )
+  .addOptionalParam(
+    "inputFolder",
+    "path to location containing deploymentArgsTemplate, and deploymentList"
+  )
+  .addOptionalParam("outputFolder", "output folder path to save factory state")
+  .setAction(async (taskArgs, hre) => {
+    let cumulativeGasUsed = BigNumber.from("0");
+    await checkUserDirPath(taskArgs.outputFolder);
+    const configDirPath =
+      taskArgs.outputFolder === undefined
+        ? DEFAULT_CONFIG_OUTPUT_DIR
+        : taskArgs.outputFolder;
+    const path =
+      configDirPath === undefined
+        ? DEFAULT_CONFIG_OUTPUT_DIR + DEPLOYMENT_LIST_FPATH + ".json"
+        : configDirPath + DEPLOYMENT_LIST_FPATH + ".json";
+    if (!fs.existsSync(path)) {
+      const error =
+        "Could not find " +
+        DEFAULT_CONFIG_OUTPUT_DIR +
+        DEPLOYMENT_LIST_FPATH +
+        ".json file. It must be generated first with generateContractsDescriptor task";
+      throw new Error(error);
+    }
+    const rawdata = fs.readFileSync(path);
+    let json = JSON.parse(rawdata.toLocaleString());
+    if (hre.network.name === "hardhat") {
+      // hardhat is not being able to estimate correctly the tx gas due to the massive bytes array
+      // being sent as input to the function (the contract bytecode), so we need to increase the block
+      // gas limit temporally in order to deploy the template
+      await hre.network.provider.send("evm_setBlockGasLimit", [
+        "0x9000000000000000",
+      ]);
+    }
+    const artifacts = hre.artifacts;
+    // deploy the factory first
+    let factoryAddress = taskArgs.factoryAddress;
+    if (factoryAddress === undefined) {
+      const factoryData: FactoryData = await hre.run("deployFactory", {
+        outputFolder: taskArgs.outputFolder,
+      });
+      factoryAddress = factoryData.address;
+      cumulativeGasUsed = cumulativeGasUsed.add(factoryData.gas);
+    }
+    const factoryBase = await hre.ethers.getContractFactory(ALICENET_FACTORY);
+    const factory = factoryBase.attach(factoryAddress);
+    let multiCallArgsArray: any[];
+    let txCount: number;
+    const staticAddresses = new Array();
+    const upgradeableAddresses = new Array();
+    const templateAddresses = new Array();
+    txCount = await hre.ethers.provider.getTransactionCount(factory.address);
+    let contracts = json.contracts;
+    multiCallArgsArray = await getMulticallArgs(
+      contracts,
+      hre,
+      factoryBase,
+      factory,
+      txCount,
+      taskArgs.inputFolder,
+      taskArgs.outputFolder
+    );
+    /* 
+    let txResponse = await factory.multiCall(multiCallArgsArray);
+    let receipt = await txResponse.wait();
+    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
+    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
+      staticAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
+      templateAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
+      upgradeableAddresses.push(o);
+    });
+    multiCallArgsArray = await getMulticallArgs(
+      contracts,
+      hre,
+      factoryBase,
+      factory,
+      txCount,
+      "ethdkg",
+      [0, 1],
+      taskArgs.inputFolder,
+      taskArgs.outputFolder
+    );
+    txResponse = await factory.multiCall(multiCallArgsArray);
+    receipt = await txResponse.wait();
+    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
+    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
+      staticAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
+      templateAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
+      upgradeableAddresses.push(o);
+    });
+    multiCallArgsArray = await getMulticallArgs(
+      contracts,
+      hre,
+      factoryBase,
+      factory,
+      txCount,
+      "ethdkg",
+      [2],
+      taskArgs.inputFolder,
+      taskArgs.outputFolder
+    );
+    txResponse = await factory.multiCall(multiCallArgsArray);
+    receipt = await txResponse.wait();
+    cumulativeGasUsed = cumulativeGasUsed.add(receipt.gasUsed);
+    getMultipleEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR).map((o) => {
+      staticAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_TEMPLATE, CONTRACT_ADDR).map((o) => {
+      templateAddresses.push(o);
+    });
+    getMultipleEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR).map((o) => {
+      upgradeableAddresses.push(o);
+    });
+    console.log("staticAddresses", staticAddresses);
+    console.log("upgradeableAddresses", upgradeableAddresses);
+ */
+    console.log(`total gas used: ${cumulativeGasUsed.toString()}`);
+  });
+
 async function checkUserDirPath(path: string) {
   if (path !== undefined) {
     if (!fs.existsSync(path)) {
@@ -1076,7 +1292,7 @@ function extractPath(qualifiedName: string) {
  * @param varName
  * @returns
  */
-function getEventVar(
+export function getEventVar(
   receipt: ContractReceipt,
   eventName: string,
   varName: string
@@ -1173,3 +1389,41 @@ export const showState = async (message: string): Promise<void> => {
     console.log(message);
   }
 };
+
+/**
+ * @description goes through the receipt from the
+ * transaction and extract multiples values for event and variable specified
+ * @param receipt tx object returned from the tran
+ * @param eventName
+ * @param varName
+ * @returns array of values
+ */
+function getMultipleEventVar(
+  receipt: ContractReceipt,
+  eventName: string,
+  varName: string
+) {
+  let result = "0x";
+  let results = Array();
+  if (receipt.events !== undefined) {
+    const events = receipt.events;
+    for (let i = 0; i < events.length; i++) {
+      // look for the event
+      if (events[i].event === eventName) {
+        if (events[i].args !== undefined) {
+          const args = events[i].args;
+          // extract the deployed mock logic contract address from the event
+          result = args !== undefined ? args[varName] : undefined;
+          if (result !== undefined) {
+            results.push(result);
+          }
+        } else {
+          throw new Error(
+            `failed to extract ${varName} from event: ${eventName}`
+          );
+        }
+      }
+    }
+  }
+  return results;
+}

--- a/bridge/scripts/lib/deployment/deploymentUtil.ts
+++ b/bridge/scripts/lib/deployment/deploymentUtil.ts
@@ -1,8 +1,32 @@
 import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
-import { BytesLike } from "ethers";
-import { Artifacts, RunTaskFunction } from "hardhat/types";
-import { DEFAULT_CONFIG_OUTPUT_DIR, INITIALIZER } from "../constants";
+import { BytesLike, ContractFactory } from "ethers";
+import {
+  Artifacts,
+  HardhatRuntimeEnvironment,
+  RunTaskFunction,
+} from "hardhat/types";
+import {
+  AliceNetFactory,
+  AliceNetFactory__factory,
+} from "../../../typechain-types";
+import { getEventVar } from "../alicenetFactoryTasks";
+import {
+  CONTRACT_ADDR,
+  DEFAULT_CONFIG_OUTPUT_DIR,
+  DEPLOYED_PROXY,
+  DEPLOYED_STATIC,
+  DEPLOY_CREATE,
+  DEPLOY_PROXY,
+  DEPLOY_STATIC,
+  DEPLOY_TEMPLATE,
+  INITIALIZER,
+  ONLY_PROXY,
+  STATIC_DEPLOYMENT,
+  UPGRADEABLE_DEPLOYMENT,
+  UPGRADE_PROXY,
+} from "../constants";
 import { readDeploymentArgs } from "./deploymentConfigUtil";
+import { ProxyData } from "./factoryStateUtil";
 
 type Ethers = typeof import("../../../node_modules/ethers/lib/ethers") &
   HardhatEthersHelpers;
@@ -45,6 +69,16 @@ export type Args = {
 export interface InitData {
   constructorArgs: { [key: string]: any };
   initializerArgs: { [key: string]: any };
+}
+
+export interface ContractDescriptor {
+  name: string;
+  fullyQualifiedName: string;
+  deployGroup: string;
+  deployGroupIndex: number;
+  deployType: string;
+  constructorArgs: [];
+  initializerArgs: [];
 }
 
 // function to deploy the factory
@@ -291,4 +325,166 @@ export async function getDeployGroupIndex(
   artifacts: Artifacts
 ) {
   return await getCustomNSTag(fullName, "deploy-group-index", artifacts);
+}
+
+export async function getDeployStaticMultiCallArgs(
+  contractDescriptor: ContractDescriptor,
+  hre: HardhatRuntimeEnvironment,
+  factoryBase: AliceNetFactory__factory,
+  factory: AliceNetFactory,
+  txCount: number
+) {
+  const logicContract: ContractFactory = await hre.ethers.getContractFactory(
+    contractDescriptor.name
+  );
+  const logicFactory = await hre.ethers.getContractFactory(
+    contractDescriptor.name
+  );
+  const deployTxReq = logicContract.getDeployTransaction(
+    ...contractDescriptor.constructorArgs
+  );
+  let initCallData = "0x";
+  if (contractDescriptor.initializerArgs.length > 0)
+    initCallData = logicFactory.interface.encodeFunctionData(
+      INITIALIZER,
+      contractDescriptor.initializerArgs
+    );
+  const salt = hre.ethers.utils.formatBytes32String(contractDescriptor.name);
+  const deployTemplate: BytesLike = factoryBase.interface.encodeFunctionData(
+    DEPLOY_TEMPLATE,
+    [deployTxReq.data]
+  );
+  const deployStatic: BytesLike = factoryBase.interface.encodeFunctionData(
+    DEPLOY_STATIC,
+    [salt, initCallData]
+  );
+  return [deployTemplate, deployStatic];
+}
+
+export async function getDeployUpgradeableMultiCallArgs(
+  contractDescriptor: ContractDescriptor,
+  hre: HardhatRuntimeEnvironment,
+  factoryBase: AliceNetFactory__factory,
+  factory: AliceNetFactory,
+  txCount: number
+) {
+  const logicContract: ContractFactory = await hre.ethers.getContractFactory(
+    contractDescriptor.name
+  );
+  const logicFactory = await hre.ethers.getContractFactory(
+    contractDescriptor.name
+  );
+  const deployTxReq = logicContract.getDeployTransaction(
+    ...contractDescriptor.constructorArgs
+  );
+  const functions = JSON.parse(
+    JSON.stringify(logicFactory.interface.functions)
+  );
+  let initCallData = "0x";
+  if (contractDescriptor.initializerArgs.length > 0)
+    initCallData = logicFactory.interface.encodeFunctionData(
+      INITIALIZER,
+      contractDescriptor.initializerArgs
+    );
+  const salt = hre.ethers.utils.formatBytes32String(contractDescriptor.name);
+  const nonce = await hre.ethers.provider.getTransactionCount(factory.address);
+  const logicAddress = hre.ethers.utils.getContractAddress({
+    from: factory.address,
+    nonce: nonce,
+  });
+
+  // encode deploy create
+  const deployCreate: BytesLike = factoryBase.interface.encodeFunctionData(
+    DEPLOY_CREATE,
+    [deployTxReq.data]
+  );
+  // encode the deployProxy function call with Salt as arg
+  const deployProxy: BytesLike = factoryBase.interface.encodeFunctionData(
+    DEPLOY_PROXY,
+    [salt]
+  );
+  // encode upgrade proxy multicall
+  const upgradeProxy: BytesLike = factoryBase.interface.encodeFunctionData(
+    UPGRADE_PROXY,
+    [salt, logicAddress, initCallData]
+  );
+  const multiCallArgs = [deployCreate, deployProxy, upgradeProxy];
+  return multiCallArgs;
+}
+
+export async function getMulticallArgs(
+  contracts: ContractDescriptor[],
+  hre: HardhatRuntimeEnvironment,
+  factoryBase: AliceNetFactory__factory,
+  factory: AliceNetFactory,
+  txCount: number,
+  inputFolder?: string,
+  outputFolder?: string
+) {
+  let proxyData: ProxyData;
+  let multiCallArgsArray = Array();
+
+  for (let i = 0; i < contracts.length; i++) {
+    const contract = contracts[i];
+    if (true) {
+      const deployType = contract.deployType;
+      switch (deployType) {
+        case STATIC_DEPLOYMENT: {
+          let multiCallArgsArray = Array();
+          let [deployTemplate, deployStatic] =
+            await getDeployStaticMultiCallArgs(
+              contract,
+              hre,
+              factoryBase,
+              factory,
+              txCount
+            );
+          multiCallArgsArray.push(deployTemplate);
+          multiCallArgsArray.push(deployStatic);
+          const txResponse = await factory.multiCall(multiCallArgsArray);
+          const receipt = await txResponse.wait();
+          const address = getEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR);
+          console.log(contract.name, "deployed at:", address);
+          break;
+        }
+        case UPGRADEABLE_DEPLOYMENT: {
+          let multiCallArgsArray = Array();
+          let [deployCreate, deployProxy, upgradeProxy] =
+            await getDeployUpgradeableMultiCallArgs(
+              contract,
+              hre,
+              factoryBase,
+              factory,
+              txCount
+            );
+          multiCallArgsArray.push(deployCreate);
+          multiCallArgsArray.push(deployProxy);
+          multiCallArgsArray.push(upgradeProxy);
+          const txResponse = await factory.multiCall(multiCallArgsArray);
+          const receipt = await txResponse.wait();
+          const address = getEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR);
+          console.log(contract.name, "deployed at:", address);
+          break;
+        }
+        case ONLY_PROXY: {
+          const name = extractName(contract.fullyQualifiedName);
+          const salt: BytesLike = await getBytes32Salt(
+            name,
+            hre.artifacts,
+            hre.ethers
+          );
+          const factoryAddress = factory.address;
+          proxyData = await hre.run("deployProxy", {
+            factoryAddress,
+            salt,
+          });
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+  }
+  return multiCallArgsArray;
 }

--- a/scripts/base-files/deploymentList.json
+++ b/scripts/base-files/deploymentList.json
@@ -1,0 +1,139 @@
+{
+    "contracts": [
+        {
+            "name": "AToken",
+            "fullyQualifiedName": "contracts/AToken.sol:AToken",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployStatic",
+            "constructorArgs": ["0x546f99f244b7b58b855330ae0e2bc1b30b41302f"],
+            "initializerArgs": []
+        },
+        {
+            "name": "ATokenBurner",
+            "fullyQualifiedName": "contracts/ATokenBurner.sol:ATokenBurner",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "ATokenMinter",
+            "fullyQualifiedName": "contracts/ATokenMinter.sol:ATokenMinter",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "BToken",
+            "fullyQualifiedName": "contracts/BToken.sol:BToken",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployStatic",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "Foundation",
+            "fullyQualifiedName": "contracts/Foundation.sol:Foundation",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "Governance",
+            "fullyQualifiedName": "contracts/Governance.sol:Governance",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "LiquidityProviderStaking",
+            "fullyQualifiedName": "contracts/LiquidityProviderStaking.sol:LiquidityProviderStaking",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "PublicStaking",
+            "fullyQualifiedName": "contracts/PublicStaking.sol:PublicStaking",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "Snapshots",
+            "fullyQualifiedName": "contracts/Snapshots.sol:Snapshots",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": ["1337", "1024"],
+            "initializerArgs": ["10", "40"]
+        },
+        {
+            "name": "StakingPositionDescriptor",
+            "fullyQualifiedName": "contracts/StakingPositionDescriptor.sol:StakingPositionDescriptor",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "ValidatorPool",
+            "fullyQualifiedName": "contracts/ValidatorPool.sol:ValidatorPool",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": ["1", "10", "1"]
+        },
+        {
+            "name": "ValidatorStaking",
+            "fullyQualifiedName": "contracts/ValidatorStaking.sol:ValidatorStaking",
+            "deployGroup": "general",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "ETHDKGAccusations",
+            "fullyQualifiedName": "contracts/libraries/ethdkg/ETHDKGAccusations.sol:ETHDKGAccusations",
+            "deployGroup": "ethdkg",
+            "deployGroupIndex": "0",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "ETHDKGPhases",
+            "fullyQualifiedName": "contracts/libraries/ethdkg/ETHDKGPhases.sol:ETHDKGPhases",
+            "deployGroup": "ethdkg",
+            "deployGroupIndex": "1",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": []
+        },
+        {
+            "name": "ETHDKG",
+            "fullyQualifiedName": "contracts/ETHDKG.sol:ETHDKG",
+            "deployGroup": "ethdkg",
+            "deployGroupIndex": "2",
+            "deployType": "deployUpgradeable",
+            "constructorArgs": [],
+            "initializerArgs": ["40", "6"]
+        }
+    ]
+}


### PR DESCRIPTION
## Scope
This PR adds two new hardhat tasks:
1) generateContractsDescriptor: Generates a JSON descriptor file with all contract deployment requirements (name, type, constructor args, initializer args, etc) using slow function getBuildInfo
2) deployContractsFromDescriptor: Deploy contracts with information from once created JSON file

## Why?
To speed up contract deployment through deployContracts actual task, benchmarks shows deployContractsFromDescriptor is 5 times faster against hardhat node and almost 2 times faster against geth.


